### PR TITLE
Minor fixes for scheduling scripts

### DIFF
--- a/schedule-now-3x/readme.md
+++ b/schedule-now-3x/readme.md
@@ -13,3 +13,8 @@ The default times can be passed to the script as command line argument. For
 example, to schedule a 15min recording in 5 min run:
 
     sh schedule-now.sh 5 15
+
+A more complex example: To schedule 100 recordings of 5 minutes each, starting
+in 1 minute, and at 15 minute intervals after that:
+
+for i in {0..100}; do sh schedule-now.sh $((15 * i + 1)) 5; done

--- a/schedule-now-3x/schedule-now.sh
+++ b/schedule-now-3x/schedule-now.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
 
 CAPTURE_AGENT="pyca"
-SERVER="https://octestallinone.virtuos.uos.de"
+HOST="http://localhost:8080"
 USER="opencast_system_account"
 PASSWORD="CHANGE_ME"
 
-
-set -eu
+set -eux
 
 if [ "$#" -eq 0 ]; then
     START_MIN=1
@@ -21,7 +20,8 @@ fi
 TMP="$(mktemp)"
 NOW="$(date --utc +%Y-%m-%dT%H:%MZ)"
 START="$(date -d "${START_MIN} min" --utc +%Y-%m-%dT%H:%MZ)"
-END="$(date -d "${END_MIN} min" --utc +%Y-%m-%dT%H:%MZ)"
+END_CALC=$((START_MIN + END_MIN)) #We want the end time to be start time + duration
+END="$(date -d "${END_CALC} min" --utc +%Y-%m-%dT%H:%MZ)"
 
 echo '<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <dublincore xmlns="http://www.opencastproject.org/xsd/1.0/dublincore/"

--- a/schedule-now-4x/readme.md
+++ b/schedule-now-4x/readme.md
@@ -15,3 +15,8 @@ The default times can be passed to the script as command line argument. For
 example, to schedule a 15min recording in 5 min run:
 
     sh schedule-now.sh 5 15
+
+A more complex example: To schedule 100 recordings of 5 minutes each, starting
+in 1 minute, and at 15 minute intervals after that:
+
+for i in {0..100}; do sh schedule-now.sh $((15 * i + 1)) 5; done

--- a/schedule-now-4x/schedule-now.sh
+++ b/schedule-now-4x/schedule-now.sh
@@ -20,7 +20,8 @@ fi
 TMP_MP="$(mktemp)"
 TMP_DC="$(mktemp)"
 START="$(date -d "${START_MIN} min" --utc +%Y-%m-%dT%H:%MZ)"
-END="$(date -d "${END_MIN} min" --utc +%Y-%m-%dT%H:%MZ)"
+END_CALC=$((START_MIN + END_MIN)) #We want the end time to be start time + duration
+END="$(date -d "${END_CALC} min" --utc +%Y-%m-%dT%H:%MZ)"
 
 echo '<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <dublincore xmlns="http://www.opencastproject.org/xsd/1.0/dublincore/"


### PR DESCRIPTION
- Resolved issue where end times were miscalculated in looping scenarios
- changed default scheduling host on the 3x script
- added example scheduling loop to the docs