### PR TITLE
Script to generate list of translation status

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,3 +63,8 @@ jobs:
       script:
         - shellcheck start-workflow-from-archive/*.sh
         - flake8 start-workflow-from-archive/*.py
+
+    - stage: test
+      env: name=translation-progress
+      script:
+        - shellcheck release-management/translation-progress/translation-progress.sh

--- a/release-management/translation-progress/readme.md
+++ b/release-management/translation-progress/readme.md
@@ -1,0 +1,33 @@
+Format Translation Status
+=========================
+
+A simple script to generate a list of all of Opencast's target language ranked
+by their current translation state:
+
+```sh
+% ./translation-progress.sh
+100 Greek
+100 German
+100 English, United Kingdom
+ 99 Spanish
+ 99 Galician
+ 90 Danish
+ 86 Hebrew
+ 86 French
+ 86 Dutch
+ 83 Chinese Traditional
+ 80 Swedish
+ 79 Tagalog
+ 79 Slovenian
+ 77 Turkish
+ 75 Polish
+ 74 Chinese Simplified
+ 72 Filipino
+ 52 Portuguese, Brazilian
+ 22 Italian
+ 11 Japanese
+  7 Russian
+  0 Portuguese
+  0 Norwegian
+  0 Finnish
+```

--- a/release-management/translation-progress/translation-progress.sh
+++ b/release-management/translation-progress/translation-progress.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -ue
+
+key="$(awk '{print $2};' < ~/.crowdin.yaml)"
+curl -s "https://api.crowdin.com/api/project/opencast-community/status?key=$key" \
+	| grep 'name\|translated_progress' \
+	| tr '\n' ' ' \
+	| sed "s/<\\/translated_progress>/\\n/g" \
+	| sed 's#^.*<name>\(.*\)</name.*progress>\(.*\)#\2 \1#' \
+	| sort -hr \
+	| sed 's/^\(.[^ ]\) / \1 /' \
+	| sed 's/^\([^ ]\) /  \1 /'


### PR DESCRIPTION
A simple script to generate a list of all of Opencast's target language ranked
by their current translation state.