### PR TITLE
Improving usability of ingest-addtrack

### DIFF
--- a/generate-maven-notices/parse-licenses.py
+++ b/generate-maven-notices/parse-licenses.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+from sys import argv
+
+if len(argv) < 2:
+    print("Usage:", "python", argv[0], "<path to dependency.html>")
+    exit(1)
+
+if "rest-test-environment" in argv[1] or "hello-world-impl" in argv[1]:
+    exit(0)
+
+with Path(argv[1]).open("r") as f:
+    line = f.readline()
+    classifier = False
+    while "</table>" not in line:
+        line = f.readline()
+        if "<tr" in line:
+            line = f.readline()
+            gid = line[line.find(">") + 1 : line.rfind("<")]
+            if gid == "org.opencastproject":
+                continue
+            line = f.readline()
+            if "<a" in line:
+                aid = line[line.find('">') + 2 : line.rfind("</a")]
+            else:
+                aid = line[line.find(">") + 1 : line.find("</")]
+            line = f.readline()
+            line = f.readline()
+            if "Classifier" in line or classifier:
+                classifier = True
+                line = f.readline()
+            line = f.readline()
+            if "<a" in line:
+                licenses = []
+                for l in line.split("</a>")[:-1]:
+                    start = l.find('">') + 2
+                    if l[start:]:
+                        licenses.append(l[start:])
+                lic = "-".join(licenses)
+            else:
+                lic = line[line.find(">") + 1 : line.find("</")]
+            print("  " + "{:<38}".format(gid) + " " + "{:<49}".format(aid) + lic)

--- a/generate-maven-notices/print-licenses.sh
+++ b/generate-maven-notices/print-licenses.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+echo "generating html files"
+mvn license:third-party-report > /dev/null
+echo ""
+
+for f in $(find . -name 'dependencies.html' | sort); do
+	echo $f | cut -d '/' -f 3
+   	python parse-licenses.py $f
+	echo ""
+	echo ""
+done

--- a/ingest/ingest-addtrack.sh
+++ b/ingest/ingest-addtrack.sh
@@ -3,9 +3,15 @@
 set -eux
 
 HOST="https://develop.opencast.org"
+if [ $# -ge 1 ]; then
+  HOST=$1
+fi
 USER="opencast_system_account"
 PASSWORD="CHANGE_ME"
-WORKFLOW='fast'
+WORKFLOW='schedule-and-upload'
+if [ $# -ge 2 ]; then
+  WORKFLOW=$2
+fi
 
 TMP_MP="$(mktemp)"
 TMP_DC="$(mktemp)"


### PR DESCRIPTION
I always forget to change the host and workflow id.  Let's add a quick-and-dirty way to change that.