### PR TITLE
Additional workflow visual comparison sample 3D gnuplot helper script

### DIFF
--- a/visualize-workflow/example-workflow.svg
+++ b/visualize-workflow/example-workflow.svg
@@ -1,0 +1,478 @@
+<?xml version="1.0" encoding="utf-8"  standalone="no"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink">
+
+    <title>Gnuplot</title>
+    <desc>Produced by GNUPLOT 5.5 patchlevel 0 </desc>
+
+    <g id="gnuplot_canvas">
+
+        <rect x="0" y="0" width="1600" height="900" fill="#ffffff"/>
+        <defs>
+
+            <circle id="gpDot" r="0.5" stroke-width="0.5" stroke="currentColor"/>
+            <path id="gpPt0" stroke-width="0.133" stroke="currentColor" d="M-1,0 h2 M0,-1 v2"/>
+            <path id="gpPt1" stroke-width="0.133" stroke="currentColor" d="M-1,-1 L1,1 M1,-1 L-1,1"/>
+            <path id="gpPt2" stroke-width="0.133" stroke="currentColor"
+                d="M-1,0 L1,0 M0,-1 L0,1 M-1,-1 L1,1 M-1,1 L1,-1"/>
+            <rect id="gpPt3" stroke-width="0.133" stroke="currentColor" x="-1" y="-1" width="2"
+                height="2"/>
+            <rect id="gpPt4" stroke-width="0.133" stroke="currentColor" fill="currentColor" x="-1"
+                y="-1" width="2" height="2"/>
+            <circle id="gpPt5" stroke-width="0.133" stroke="currentColor" cx="0" cy="0" r="1"/>
+            <use xlink:href="#gpPt5" id="gpPt6" fill="currentColor" stroke="none"/>
+            <path id="gpPt7" stroke-width="0.133" stroke="currentColor"
+                d="M0,-1.33 L-1.33,0.67 L1.33,0.67 z"/>
+            <use xlink:href="#gpPt7" id="gpPt8" fill="currentColor" stroke="none"/>
+            <use xlink:href="#gpPt7" id="gpPt9" stroke="currentColor" transform="rotate(180)"/>
+            <use xlink:href="#gpPt9" id="gpPt10" fill="currentColor" stroke="none"/>
+            <use xlink:href="#gpPt3" id="gpPt11" stroke="currentColor" transform="rotate(45)"/>
+            <use xlink:href="#gpPt11" id="gpPt12" fill="currentColor" stroke="none"/>
+            <path id="gpPt13" stroke-width="0.133" stroke="currentColor"
+                d="M0,1.330 L1.265,0.411 L0.782,-1.067 L-0.782,-1.076 L-1.265,0.411 z"/>
+            <use xlink:href="#gpPt13" id="gpPt14" fill="currentColor" stroke="none"/>
+            <filter id="textbox" filterUnits="objectBoundingBox" x="0" y="0" height="1" width="1">
+                <feFlood flood-color="#FFFFFF" flood-opacity="1" result="bgnd"/>
+                <feComposite in="SourceGraphic" in2="bgnd" operator="atop"/>
+            </filter>
+            <filter id="greybox" filterUnits="objectBoundingBox" x="0" y="0" height="1" width="1">
+                <feFlood flood-color="lightgrey" flood-opacity="1" result="grey"/>
+                <feComposite in="SourceGraphic" in2="grey" operator="atop"/>
+            </filter>
+        </defs>
+        <g fill="none" color="#FFFFFF" stroke="currentColor" stroke-width="1.00"
+            stroke-linecap="butt" stroke-linejoin="miter"> </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M121.0,632.0 L136.0,632.0 M1557.9,632.0 L1542.9,632.0  "/>
+            <g transform="translate(107.0,638.5)" stroke="none" fill="black" font-family="Sans"
+                font-size="20.00" font-weight="bold" text-anchor="end">
+                <text><tspan font-family="Sans"> 0</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M121.0,564.3 L136.0,564.3 M1557.9,564.3 L1542.9,564.3  "/>
+            <g transform="translate(107.0,570.8)" stroke="none" fill="black" font-family="Sans"
+                font-size="20.00" font-weight="bold" text-anchor="end">
+                <text><tspan font-family="Sans"> 100</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M121.0,496.5 L136.0,496.5 M1557.9,496.5 L1542.9,496.5  "/>
+            <g transform="translate(107.0,503.0)" stroke="none" fill="black" font-family="Sans"
+                font-size="20.00" font-weight="bold" text-anchor="end">
+                <text><tspan font-family="Sans"> 200</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M121.0,428.8 L136.0,428.8 M1557.9,428.8 L1542.9,428.8  "/>
+            <g transform="translate(107.0,435.3)" stroke="none" fill="black" font-family="Sans"
+                font-size="20.00" font-weight="bold" text-anchor="end">
+                <text><tspan font-family="Sans"> 300</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M121.0,361.0 L136.0,361.0 M1557.9,361.0 L1542.9,361.0  "/>
+            <g transform="translate(107.0,367.5)" stroke="none" fill="black" font-family="Sans"
+                font-size="20.00" font-weight="bold" text-anchor="end">
+                <text><tspan font-family="Sans"> 400</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M121.0,293.3 L136.0,293.3 M1557.9,293.3 L1542.9,293.3  "/>
+            <g transform="translate(107.0,299.8)" stroke="none" fill="black" font-family="Sans"
+                font-size="20.00" font-weight="bold" text-anchor="end">
+                <text><tspan font-family="Sans"> 500</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M121.0,225.6 L136.0,225.6 M1557.9,225.6 L1542.9,225.6  "/>
+            <g transform="translate(107.0,232.1)" stroke="none" fill="black" font-family="Sans"
+                font-size="20.00" font-weight="bold" text-anchor="end">
+                <text><tspan font-family="Sans"> 600</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M121.0,157.8 L136.0,157.8 M1557.9,157.8 L1542.9,157.8  "/>
+            <g transform="translate(107.0,164.3)" stroke="none" fill="black" font-family="Sans"
+                font-size="20.00" font-weight="bold" text-anchor="end">
+                <text><tspan font-family="Sans"> 700</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M121.0,90.1 L136.0,90.1 M1557.9,90.1 L1542.9,90.1  "/>
+            <g transform="translate(107.0,96.6)" stroke="none" fill="black" font-family="Sans"
+                font-size="20.00" font-weight="bold" text-anchor="end">
+                <text><tspan font-family="Sans"> 800</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M194.7,632.0 L194.7,617.0 M194.7,90.1 L194.7,105.1  "/>
+            <g transform="translate(201.2,646.0) rotate(270)" stroke="none" fill="black"
+                font-family="Sans" font-size="20.00" font-weight="bold" text-anchor="end">
+                <text><tspan font-family="Sans">defaults</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M286.8,632.0 L286.8,617.0 M286.8,90.1 L286.8,105.1  "/>
+            <g transform="translate(293.3,646.0) rotate(270)" stroke="none" fill="black"
+                font-family="Sans" font-size="20.00" font-weight="bold" text-anchor="end">
+                <text><tspan font-family="Sans">defaults</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M378.9,632.0 L378.9,617.0 M378.9,90.1 L378.9,105.1  "/>
+            <g transform="translate(385.4,646.0) rotate(270)" stroke="none" fill="black"
+                font-family="Sans" font-size="20.00" font-weight="bold" text-anchor="end">
+                <text><tspan font-family="Sans">series</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M471.0,632.0 L471.0,617.0 M471.0,90.1 L471.0,105.1  "/>
+            <g transform="translate(477.5,646.0) rotate(270)" stroke="none" fill="black"
+                font-family="Sans" font-size="20.00" font-weight="bold" text-anchor="end">
+                <text><tspan font-family="Sans">inspect</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M563.1,632.0 L563.1,617.0 M563.1,90.1 L563.1,105.1  "/>
+            <g transform="translate(569.6,646.0) rotate(270)" stroke="none" fill="black"
+                font-family="Sans" font-size="20.00" font-weight="bold" text-anchor="end">
+                <text><tspan font-family="Sans">encode</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M655.2,632.0 L655.2,617.0 M655.2,90.1 L655.2,105.1  "/>
+            <g transform="translate(661.7,646.0) rotate(270)" stroke="none" fill="black"
+                font-family="Sans" font-size="20.00" font-weight="bold" text-anchor="end">
+                <text><tspan font-family="Sans">image</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M747.3,632.0 L747.3,617.0 M747.3,90.1 L747.3,105.1  "/>
+            <g transform="translate(753.8,646.0) rotate(270)" stroke="none" fill="black"
+                font-family="Sans" font-size="20.00" font-weight="bold" text-anchor="end">
+                <text><tspan font-family="Sans">image</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M839.5,632.0 L839.5,617.0 M839.5,90.1 L839.5,105.1  "/>
+            <g transform="translate(846.0,646.0) rotate(270)" stroke="none" fill="black"
+                font-family="Sans" font-size="20.00" font-weight="bold" text-anchor="end">
+                <text><tspan font-family="Sans">segment-video</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M931.6,632.0 L931.6,617.0 M931.6,90.1 L931.6,105.1  "/>
+            <g transform="translate(938.1,646.0) rotate(270)" stroke="none" fill="black"
+                font-family="Sans" font-size="20.00" font-weight="bold" text-anchor="end">
+                <text><tspan font-family="Sans">segmentpreviews</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M1023.7,632.0 L1023.7,617.0 M1023.7,90.1 L1023.7,105.1  "/>
+            <g transform="translate(1030.2,646.0) rotate(270)" stroke="none" fill="black"
+                font-family="Sans" font-size="20.00" font-weight="bold" text-anchor="end">
+                <text><tspan font-family="Sans">timelinepreviews</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M1115.8,632.0 L1115.8,617.0 M1115.8,90.1 L1115.8,105.1  "/>
+            <g transform="translate(1122.3,646.0) rotate(270)" stroke="none" fill="black"
+                font-family="Sans" font-size="20.00" font-weight="bold" text-anchor="end">
+                <text><tspan font-family="Sans">extract-text</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M1207.9,632.0 L1207.9,617.0 M1207.9,90.1 L1207.9,105.1  "/>
+            <g transform="translate(1214.4,646.0) rotate(270)" stroke="none" fill="black"
+                font-family="Sans" font-size="20.00" font-weight="bold" text-anchor="end">
+                <text><tspan font-family="Sans">publish-configure</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M1300.0,632.0 L1300.0,617.0 M1300.0,90.1 L1300.0,105.1  "/>
+            <g transform="translate(1306.5,646.0) rotate(270)" stroke="none" fill="black"
+                font-family="Sans" font-size="20.00" font-weight="bold" text-anchor="end">
+                <text><tspan font-family="Sans">publish-engage</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M1392.1,632.0 L1392.1,617.0 M1392.1,90.1 L1392.1,105.1  "/>
+            <g transform="translate(1398.6,646.0) rotate(270)" stroke="none" fill="black"
+                font-family="Sans" font-size="20.00" font-weight="bold" text-anchor="end">
+                <text><tspan font-family="Sans">snapshot</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M1484.2,632.0 L1484.2,617.0 M1484.2,90.1 L1484.2,105.1  "/>
+            <g transform="translate(1490.7,646.0) rotate(270)" stroke="none" fill="black"
+                font-family="Sans" font-size="20.00" font-weight="bold" text-anchor="end">
+                <text><tspan font-family="Sans">cleanup</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter"> </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M121.0,90.1 L121.0,632.0 L1557.9,632.0 L1557.9,90.1 L121.0,90.1 Z  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <g transform="translate(32.0,361.1) rotate(270)" stroke="none" fill="black"
+                font-family="Sans" font-size="20.00" font-weight="bold" text-anchor="middle">
+                <text><tspan font-family="Sans">Time [s]</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter"> </g>
+        <g id="gnuplot_plot_1a">
+            <title>gnuplot_plot_1a</title>
+            <g fill="none" color="black" stroke="currentColor" stroke-width="1.00"
+                stroke-linecap="butt" stroke-linejoin="miter">
+                <g stroke="none" shape-rendering="crispEdges">
+                    <polygon fill="rgb(  0,   0,   0)"
+                        points="157.8,632.0 231.6,632.0 231.6,631.9 157.8,631.9 "/>
+                </g>
+                <path stroke="black" d="M157.8,632.0 L231.5,632.0 L157.8,632.0 Z  "/>
+            </g>
+            <g fill="none" color="black" stroke="currentColor" stroke-width="1.00"
+                stroke-linecap="butt" stroke-linejoin="miter">
+                <g stroke="none" shape-rendering="crispEdges">
+                    <polygon fill="rgb(  0,   0,   0)"
+                        points="250.0,632.0 323.7,632.0 323.7,631.9 250.0,631.9 "/>
+                </g>
+                <path stroke="black" d="M250.0,632.0 L323.6,632.0 L250.0,632.0 Z  "/>
+            </g>
+            <g fill="none" color="black" stroke="currentColor" stroke-width="1.00"
+                stroke-linecap="butt" stroke-linejoin="miter">
+                <g stroke="none" shape-rendering="crispEdges">
+                    <polygon fill="rgb(  0,   0,   0)"
+                        points="342.1,632.0 415.8,632.0 415.8,631.8 342.1,631.8 "/>
+                </g>
+                <path stroke="black"
+                    d="M342.1,632.0 L342.1,631.9 L415.7,631.9 L415.7,632.0 L342.1,632.0 Z  "/>
+            </g>
+            <g fill="none" color="black" stroke="currentColor" stroke-width="1.00"
+                stroke-linecap="butt" stroke-linejoin="miter">
+                <g stroke="none" shape-rendering="crispEdges">
+                    <polygon fill="rgb(  0,   0,   0)"
+                        points="434.2,632.0 508.0,632.0 508.0,614.8 434.2,614.8 "/>
+                </g>
+                <path stroke="black"
+                    d="M434.2,632.0 L434.2,614.9 L507.9,614.9 L507.9,632.0 L434.2,632.0 Z  "/>
+            </g>
+            <g fill="none" color="black" stroke="currentColor" stroke-width="1.00"
+                stroke-linecap="butt" stroke-linejoin="miter">
+                <g stroke="none" shape-rendering="crispEdges">
+                    <polygon fill="rgb(  0,   0,   0)"
+                        points="526.3,632.0 600.1,632.0 600.1,132.9 526.3,132.9 "/>
+                </g>
+                <path stroke="black"
+                    d="M526.3,632.0 L526.3,133.0 L600.0,133.0 L600.0,632.0 L526.3,632.0 Z  "/>
+            </g>
+            <g fill="none" color="black" stroke="currentColor" stroke-width="1.00"
+                stroke-linecap="butt" stroke-linejoin="miter">
+                <g stroke="none" shape-rendering="crispEdges">
+                    <polygon fill="rgb(  0,   0,   0)"
+                        points="618.4,632.0 692.2,632.0 692.2,557.2 618.4,557.2 "/>
+                </g>
+                <path stroke="black"
+                    d="M618.4,632.0 L618.4,557.3 L692.1,557.3 L692.1,632.0 L618.4,632.0 Z  "/>
+            </g>
+            <g fill="none" color="black" stroke="currentColor" stroke-width="1.00"
+                stroke-linecap="butt" stroke-linejoin="miter">
+                <g stroke="none" shape-rendering="crispEdges">
+                    <polygon fill="rgb(  0,   0,   0)"
+                        points="710.5,632.0 784.3,632.0 784.3,560.5 710.5,560.5 "/>
+                </g>
+                <path stroke="black"
+                    d="M710.5,632.0 L710.5,560.6 L784.2,560.6 L784.2,632.0 L710.5,632.0 Z  "/>
+            </g>
+            <g fill="none" color="black" stroke="currentColor" stroke-width="1.00"
+                stroke-linecap="butt" stroke-linejoin="miter">
+                <g stroke="none" shape-rendering="crispEdges">
+                    <polygon fill="rgb(  0,   0,   0)"
+                        points="802.6,632.0 876.4,632.0 876.4,564.1 802.6,564.1 "/>
+                </g>
+                <path stroke="black"
+                    d="M802.6,632.0 L802.6,564.2 L876.3,564.2 L876.3,632.0 L802.6,632.0 Z  "/>
+            </g>
+            <g fill="none" color="black" stroke="currentColor" stroke-width="1.00"
+                stroke-linecap="butt" stroke-linejoin="miter">
+                <g stroke="none" shape-rendering="crispEdges">
+                    <polygon fill="rgb(  0,   0,   0)"
+                        points="894.7,632.0 968.5,632.0 968.5,625.1 894.7,625.1 "/>
+                </g>
+                <path stroke="black"
+                    d="M894.7,632.0 L894.7,625.2 L968.4,625.2 L968.4,632.0 L894.7,632.0 Z  "/>
+            </g>
+            <g fill="none" color="black" stroke="currentColor" stroke-width="1.00"
+                stroke-linecap="butt" stroke-linejoin="miter">
+                <g stroke="none" shape-rendering="crispEdges">
+                    <polygon fill="rgb(  0,   0,   0)"
+                        points="986.8,632.0 1060.6,632.0 1060.6,591.2 986.8,591.2 "/>
+                </g>
+                <path stroke="black"
+                    d="M986.8,632.0 L986.8,591.3 L1060.5,591.3 L1060.5,632.0 L986.8,632.0 Z  "/>
+            </g>
+            <g fill="none" color="black" stroke="currentColor" stroke-width="1.00"
+                stroke-linecap="butt" stroke-linejoin="miter">
+                <g stroke="none" shape-rendering="crispEdges">
+                    <polygon fill="rgb(  0,   0,   0)"
+                        points="1078.9,632.0 1152.7,632.0 1152.7,621.6 1078.9,621.6 "/>
+                </g>
+                <path stroke="black"
+                    d="M1078.9,632.0 L1078.9,621.7 L1152.6,621.7 L1152.6,632.0 L1078.9,632.0 Z  "/>
+            </g>
+            <g fill="none" color="black" stroke="currentColor" stroke-width="1.00"
+                stroke-linecap="butt" stroke-linejoin="miter">
+                <g stroke="none" shape-rendering="crispEdges">
+                    <polygon fill="rgb(  0,   0,   0)"
+                        points="1171.0,632.0 1244.8,632.0 1244.8,625.1 1171.0,625.1 "/>
+                </g>
+                <path stroke="black"
+                    d="M1171.0,632.0 L1171.0,625.2 L1244.7,625.2 L1244.7,632.0 L1171.0,632.0 Z  "/>
+            </g>
+            <g fill="none" color="black" stroke="currentColor" stroke-width="1.00"
+                stroke-linecap="butt" stroke-linejoin="miter">
+                <g stroke="none" shape-rendering="crispEdges">
+                    <polygon fill="rgb(  0,   0,   0)"
+                        points="1263.2,632.0 1336.9,632.0 1336.9,621.7 1263.2,621.7 "/>
+                </g>
+                <path stroke="black"
+                    d="M1263.2,632.0 L1263.2,621.8 L1336.8,621.8 L1336.8,632.0 L1263.2,632.0 Z  "/>
+            </g>
+            <g fill="none" color="black" stroke="currentColor" stroke-width="1.00"
+                stroke-linecap="butt" stroke-linejoin="miter">
+                <g stroke="none" shape-rendering="crispEdges">
+                    <polygon fill="rgb(  0,   0,   0)"
+                        points="1355.3,632.0 1429.0,632.0 1429.0,631.9 1355.3,631.9 "/>
+                </g>
+                <path stroke="black" d="M1355.3,632.0 L1428.9,632.0 L1355.3,632.0 Z  "/>
+            </g>
+            <g fill="none" color="black" stroke="currentColor" stroke-width="1.00"
+                stroke-linecap="butt" stroke-linejoin="miter">
+                <g stroke="none" shape-rendering="crispEdges">
+                    <polygon fill="rgb(  0,   0,   0)"
+                        points="1447.4,632.0 1521.2,632.0 1521.2,631.0 1447.4,631.0 "/>
+                </g>
+                <path stroke="black"
+                    d="M1447.4,632.0 L1447.4,631.1 L1521.1,631.1 L1521.1,632.0 L1447.4,632.0 Z  "/>
+            </g>
+            <g fill="none" color="black" stroke="currentColor" stroke-width="1.00"
+                stroke-linecap="butt" stroke-linejoin="miter"> </g>
+        </g>
+        <g id="gnuplot_plot_2a">
+            <title>gnuplot_plot_2a</title>
+            <g fill="none" color="black" stroke="currentColor" stroke-width="1.00"
+                stroke-linecap="butt" stroke-linejoin="miter">
+                <g transform="translate(194.7,623.5)" stroke="none" fill="black" font-family="Sans"
+                    font-size="20.00" font-weight="bold" text-anchor="middle">
+                    <text><tspan font-family="Sans">00:00</tspan></text>
+                </g>
+                <g transform="translate(286.8,623.5)" stroke="none" fill="black" font-family="Sans"
+                    font-size="20.00" font-weight="bold" text-anchor="middle">
+                    <text><tspan font-family="Sans">00:00</tspan></text>
+                </g>
+                <g transform="translate(378.9,623.4)" stroke="none" fill="black" font-family="Sans"
+                    font-size="20.00" font-weight="bold" text-anchor="middle">
+                    <text><tspan font-family="Sans">00:00</tspan></text>
+                </g>
+                <g transform="translate(471.0,606.4)" stroke="none" fill="black" font-family="Sans"
+                    font-size="20.00" font-weight="bold" text-anchor="middle">
+                    <text><tspan font-family="Sans">00:25</tspan></text>
+                </g>
+                <g transform="translate(563.1,124.5)" stroke="none" fill="black" font-family="Sans"
+                    font-size="20.00" font-weight="bold" text-anchor="middle">
+                    <text><tspan font-family="Sans">12:16</tspan></text>
+                </g>
+                <g transform="translate(655.2,548.8)" stroke="none" fill="black" font-family="Sans"
+                    font-size="20.00" font-weight="bold" text-anchor="middle">
+                    <text><tspan font-family="Sans">01:50</tspan></text>
+                </g>
+                <g transform="translate(747.3,552.1)" stroke="none" fill="black" font-family="Sans"
+                    font-size="20.00" font-weight="bold" text-anchor="middle">
+                    <text><tspan font-family="Sans">01:45</tspan></text>
+                </g>
+                <g transform="translate(839.5,555.7)" stroke="none" fill="black" font-family="Sans"
+                    font-size="20.00" font-weight="bold" text-anchor="middle">
+                    <text><tspan font-family="Sans">01:40</tspan></text>
+                </g>
+                <g transform="translate(931.6,616.7)" stroke="none" fill="black" font-family="Sans"
+                    font-size="20.00" font-weight="bold" text-anchor="middle">
+                    <text><tspan font-family="Sans">00:10</tspan></text>
+                </g>
+                <g transform="translate(1023.7,582.8)" stroke="none" fill="black" font-family="Sans"
+                    font-size="20.00" font-weight="bold" text-anchor="middle">
+                    <text><tspan font-family="Sans">01:00</tspan></text>
+                </g>
+                <g transform="translate(1115.8,613.2)" stroke="none" fill="black" font-family="Sans"
+                    font-size="20.00" font-weight="bold" text-anchor="middle">
+                    <text><tspan font-family="Sans">00:15</tspan></text>
+                </g>
+                <g transform="translate(1207.9,616.7)" stroke="none" fill="black" font-family="Sans"
+                    font-size="20.00" font-weight="bold" text-anchor="middle">
+                    <text><tspan font-family="Sans">00:10</tspan></text>
+                </g>
+                <g transform="translate(1300.0,613.3)" stroke="none" fill="black" font-family="Sans"
+                    font-size="20.00" font-weight="bold" text-anchor="middle">
+                    <text><tspan font-family="Sans">00:15</tspan></text>
+                </g>
+                <g transform="translate(1392.1,623.5)" stroke="none" fill="black" font-family="Sans"
+                    font-size="20.00" font-weight="bold" text-anchor="middle">
+                    <text><tspan font-family="Sans">00:00</tspan></text>
+                </g>
+                <g transform="translate(1484.2,622.6)" stroke="none" fill="black" font-family="Sans"
+                    font-size="20.00" font-weight="bold" text-anchor="middle">
+                    <text><tspan font-family="Sans">00:01</tspan></text>
+                </g>
+            </g>
+        </g>
+        <g fill="none" color="#FFFFFF" stroke="black" stroke-width="2.00" stroke-linecap="butt"
+            stroke-linejoin="miter"> </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="butt"
+            stroke-linejoin="miter"> </g>
+        <g fill="none" color="black" stroke="black" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter"> </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M121.0,90.1 L121.0,632.0 L1557.9,632.0 L1557.9,90.1 L121.0,90.1 Z  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <g transform="translate(839.4,51.6)" stroke="none" fill="black" font-family="Sans"
+                font-size="20.00" font-weight="bold" text-anchor="middle">
+                <text><tspan font-family="Sans">Workflow Operation Times from
+                    workflow1.dat</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter"> </g>
+    </g>
+</svg>

--- a/visualize-workflow/example-workflows-3D.svg
+++ b/visualize-workflow/example-workflows-3D.svg
@@ -1,0 +1,6921 @@
+<?xml version="1.0" encoding="utf-8"  standalone="no"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink">
+
+    <title>Gnuplot</title>
+    <desc>Produced by GNUPLOT 5.5 patchlevel 0 </desc>
+
+    <g id="gnuplot_canvas">
+
+        <rect x="0" y="0" width="1600" height="900" fill="none"/>
+        <defs>
+
+            <circle id="gpDot" r="0.5" stroke-width="0.5" stroke="currentColor"/>
+            <path id="gpPt0" stroke-width="0.267" stroke="currentColor" d="M-1,0 h2 M0,-1 v2"/>
+            <path id="gpPt1" stroke-width="0.267" stroke="currentColor" d="M-1,-1 L1,1 M1,-1 L-1,1"/>
+            <path id="gpPt2" stroke-width="0.267" stroke="currentColor"
+                d="M-1,0 L1,0 M0,-1 L0,1 M-1,-1 L1,1 M-1,1 L1,-1"/>
+            <rect id="gpPt3" stroke-width="0.267" stroke="currentColor" x="-1" y="-1" width="2"
+                height="2"/>
+            <rect id="gpPt4" stroke-width="0.267" stroke="currentColor" fill="currentColor" x="-1"
+                y="-1" width="2" height="2"/>
+            <circle id="gpPt5" stroke-width="0.267" stroke="currentColor" cx="0" cy="0" r="1"/>
+            <use xlink:href="#gpPt5" id="gpPt6" fill="currentColor" stroke="none"/>
+            <path id="gpPt7" stroke-width="0.267" stroke="currentColor"
+                d="M0,-1.33 L-1.33,0.67 L1.33,0.67 z"/>
+            <use xlink:href="#gpPt7" id="gpPt8" fill="currentColor" stroke="none"/>
+            <use xlink:href="#gpPt7" id="gpPt9" stroke="currentColor" transform="rotate(180)"/>
+            <use xlink:href="#gpPt9" id="gpPt10" fill="currentColor" stroke="none"/>
+            <use xlink:href="#gpPt3" id="gpPt11" stroke="currentColor" transform="rotate(45)"/>
+            <use xlink:href="#gpPt11" id="gpPt12" fill="currentColor" stroke="none"/>
+            <path id="gpPt13" stroke-width="0.267" stroke="currentColor"
+                d="M0,1.330 L1.265,0.411 L0.782,-1.067 L-0.782,-1.076 L-1.265,0.411 z"/>
+            <use xlink:href="#gpPt13" id="gpPt14" fill="currentColor" stroke="none"/>
+            <filter id="textbox" filterUnits="objectBoundingBox" x="0" y="0" height="1" width="1">
+                <feFlood flood-color="white" flood-opacity="1" result="bgnd"/>
+                <feComposite in="SourceGraphic" in2="bgnd" operator="atop"/>
+            </filter>
+            <filter id="greybox" filterUnits="objectBoundingBox" x="0" y="0" height="1" width="1">
+                <feFlood flood-color="lightgrey" flood-opacity="1" result="grey"/>
+                <feComposite in="SourceGraphic" in2="grey" operator="atop"/>
+            </filter>
+        </defs>
+        <g fill="none" color="white" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter"> </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter"> </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M183.4,541.6 L1114.1,438.7  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M1416.5,755.6 L1114.1,438.7  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M183.4,541.6 L183.4,144.5  "/>
+        </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M188.6,547.1 L1119.3,444.1  "/>
+        </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M1119.3,444.1 L1119.3,47.0  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M188.6,547.1 L199.3,545.9  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M1119.3,444.1 L1108.6,445.3  "/>
+            <g transform="translate(178.6,560.1)" stroke="none" fill="black" font-family="arial"
+                font-size="15.00" text-anchor="end">
+                <text><tspan font-family="arial">defaults</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter"> </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M209.4,569.0 L1140.2,466.0  "/>
+        </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M1140.2,466.0 L1140.2,68.8  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M209.4,569.0 L220.2,567.8  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M1140.2,466.0 L1129.4,467.2  "/>
+            <g transform="translate(199.5,582.0)" stroke="none" fill="black" font-family="arial"
+                font-size="15.00" text-anchor="end">
+                <text><tspan font-family="arial">defaults</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter"> </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M230.3,590.8 L1161.1,487.8  "/>
+        </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M1161.1,487.8 L1161.1,90.7  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M230.3,590.8 L241.1,589.6  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M1161.1,487.8 L1150.3,489.0  "/>
+            <g transform="translate(220.3,603.8)" stroke="none" fill="black" font-family="arial"
+                font-size="15.00" text-anchor="end">
+                <text><tspan font-family="arial">series</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter"> </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M251.1,612.7 L1181.9,509.7  "/>
+        </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M1181.9,509.7 L1181.9,112.6  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M251.1,612.7 L261.9,611.5  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M1181.9,509.7 L1171.1,510.9  "/>
+            <g transform="translate(241.2,625.7)" stroke="none" fill="black" font-family="arial"
+                font-size="15.00" text-anchor="end">
+                <text><tspan font-family="arial">inspect</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter"> </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M272.0,634.5 L1202.8,531.6  "/>
+        </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M1202.8,531.6 L1202.8,134.4  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M272.0,634.5 L282.8,633.3  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M1202.8,531.6 L1192.0,532.8  "/>
+            <g transform="translate(262.0,647.5)" stroke="none" fill="black" font-family="arial"
+                font-size="15.00" text-anchor="end">
+                <text><tspan font-family="arial">encode</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter"> </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M292.9,656.4 L1223.6,553.4  "/>
+        </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M1223.6,553.4 L1223.6,156.3  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M292.9,656.4 L303.6,655.2  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M1223.6,553.4 L1212.8,554.6  "/>
+            <g transform="translate(282.9,669.4)" stroke="none" fill="black" font-family="arial"
+                font-size="15.00" text-anchor="end">
+                <text><tspan font-family="arial">image</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter"> </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M313.7,678.3 L1244.5,575.3  "/>
+        </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M1244.5,575.3 L1244.5,178.1  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M313.7,678.3 L324.5,677.1  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M1244.5,575.3 L1233.7,576.5  "/>
+            <g transform="translate(303.7,691.2)" stroke="none" fill="black" font-family="arial"
+                font-size="15.00" text-anchor="end">
+                <text><tspan font-family="arial">image</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter"> </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M334.6,700.1 L1265.3,597.1  "/>
+        </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M1265.3,597.1 L1265.3,200.0  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M334.6,700.1 L345.3,698.9  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M1265.3,597.1 L1254.6,598.3  "/>
+            <g transform="translate(324.6,713.1)" stroke="none" fill="black" font-family="arial"
+                font-size="15.00" text-anchor="end">
+                <text><tspan font-family="arial">segment-video</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter"> </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M355.4,722.0 L1286.2,619.0  "/>
+        </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M1286.2,619.0 L1286.2,221.8  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M355.4,722.0 L366.2,720.8  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M1286.2,619.0 L1275.4,620.2  "/>
+            <g transform="translate(345.5,735.0)" stroke="none" fill="black" font-family="arial"
+                font-size="15.00" text-anchor="end">
+                <text><tspan font-family="arial">segmentpreviews</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter"> </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M376.3,743.8 L1307.0,640.8  "/>
+        </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M1307.0,640.8 L1307.0,243.7  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M376.3,743.8 L387.1,742.6  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M1307.0,640.8 L1296.3,642.0  "/>
+            <g transform="translate(366.3,756.8)" stroke="none" fill="black" font-family="arial"
+                font-size="15.00" text-anchor="end">
+                <text><tspan font-family="arial">timelinepreviews</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter"> </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M397.1,765.7 L1327.9,662.7  "/>
+        </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M1327.9,662.7 L1327.9,265.6  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M397.1,765.7 L407.9,764.5  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M1327.9,662.7 L1317.1,663.9  "/>
+            <g transform="translate(387.2,778.7)" stroke="none" fill="black" font-family="arial"
+                font-size="15.00" text-anchor="end">
+                <text><tspan font-family="arial">extract-text</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter"> </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M418.0,787.5 L1348.8,684.6  "/>
+        </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M1348.8,684.6 L1348.8,287.4  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M418.0,787.5 L428.8,786.3  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M1348.8,684.6 L1338.0,685.8  "/>
+            <g transform="translate(408.0,800.5)" stroke="none" fill="black" font-family="arial"
+                font-size="15.00" text-anchor="end">
+                <text><tspan font-family="arial">publish-configure</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter"> </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M438.8,809.4 L1369.6,706.4  "/>
+        </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M1369.6,706.4 L1369.6,309.3  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M438.8,809.4 L449.6,808.2  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M1369.6,706.4 L1358.8,707.6  "/>
+            <g transform="translate(428.9,822.4)" stroke="none" fill="black" font-family="arial"
+                font-size="15.00" text-anchor="end">
+                <text><tspan font-family="arial">publish-engage</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter"> </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M459.7,831.3 L1390.5,728.3  "/>
+        </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M1390.5,728.3 L1390.5,331.1  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M459.7,831.3 L470.5,830.1  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M1390.5,728.3 L1379.7,729.5  "/>
+            <g transform="translate(449.7,844.2)" stroke="none" fill="black" font-family="arial"
+                font-size="15.00" text-anchor="end">
+                <text><tspan font-family="arial">snapshot</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter"> </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M480.6,853.1 L1411.3,750.1  "/>
+        </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M1411.3,750.1 L1411.3,353.0  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M480.6,853.1 L491.3,851.9  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M1411.3,750.1 L1400.6,751.3  "/>
+            <g transform="translate(470.6,866.1)" stroke="none" fill="black" font-family="arial"
+                font-size="15.00" text-anchor="end">
+                <text><tspan font-family="arial">cleanup</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter"> </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M485.8,858.6 L183.4,541.6  "/>
+        </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M183.4,541.6 L183.4,144.5  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M485.8,858.6 L482.3,854.9  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M183.4,541.6 L186.9,545.3  "/>
+            <g transform="translate(489.1,876.5)" stroke="none" fill="black" font-family="arial"
+                font-size="15.00" text-anchor="middle">
+                <text><tspan font-family="arial"> 0</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter"> </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M602.1,845.7 L299.7,528.8  "/>
+        </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M299.7,528.8 L299.7,131.6  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M602.1,845.7 L598.6,842.0  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M299.7,528.8 L303.2,532.4  "/>
+            <g transform="translate(605.5,863.6)" stroke="none" fill="black" font-family="arial"
+                font-size="15.00" text-anchor="middle">
+                <text><tspan font-family="arial"> 0.5</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter"> </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M718.5,832.8 L416.0,515.9  "/>
+        </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M416.0,515.9 L416.0,118.8  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M718.5,832.8 L715.0,829.2  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M416.0,515.9 L419.5,519.6  "/>
+            <g transform="translate(721.8,850.8)" stroke="none" fill="black" font-family="arial"
+                font-size="15.00" text-anchor="middle">
+                <text><tspan font-family="arial"> 1</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter"> </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M834.8,820.0 L532.4,503.0  "/>
+        </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M532.4,503.0 L532.4,105.9  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M834.8,820.0 L831.3,816.3  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M532.4,503.0 L535.9,506.7  "/>
+            <g transform="translate(838.1,837.9)" stroke="none" fill="black" font-family="arial"
+                font-size="15.00" text-anchor="middle">
+                <text><tspan font-family="arial"> 1.5</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter"> </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M951.2,807.1 L648.7,490.2  "/>
+        </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M648.7,490.2 L648.7,93.0  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M951.2,807.1 L947.7,803.4  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M648.7,490.2 L652.2,493.8  "/>
+            <g transform="translate(954.4,825.0)" stroke="none" fill="black" font-family="arial"
+                font-size="15.00" text-anchor="middle">
+                <text><tspan font-family="arial"> 2</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter"> </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M1067.5,794.2 L765.1,477.3  "/>
+        </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M765.1,477.3 L765.1,80.1  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M1067.5,794.2 L1064.0,790.5  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M765.1,477.3 L768.6,481.0  "/>
+            <g transform="translate(1070.8,812.2)" stroke="none" fill="black" font-family="arial"
+                font-size="15.00" text-anchor="middle">
+                <text><tspan font-family="arial"> 2.5</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter"> </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M1183.9,781.3 L881.4,464.4  "/>
+        </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M881.4,464.4 L881.4,67.3  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M1183.9,781.3 L1180.4,777.7  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M881.4,464.4 L884.9,468.1  "/>
+            <g transform="translate(1187.1,799.3)" stroke="none" fill="black" font-family="arial"
+                font-size="15.00" text-anchor="middle">
+                <text><tspan font-family="arial"> 3</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter"> </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M1300.2,768.5 L997.8,451.5  "/>
+        </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M997.8,451.5 L997.8,54.4  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M1300.2,768.5 L1296.7,764.8  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M997.8,451.5 L1001.3,455.2  "/>
+            <g transform="translate(1303.5,786.4)" stroke="none" fill="black" font-family="arial"
+                font-size="15.00" text-anchor="middle">
+                <text><tspan font-family="arial"> 3.5</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter"> </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M1416.5,755.6 L1114.1,438.7  "/>
+        </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M1114.1,438.7 L1114.1,41.5  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M1416.5,755.6 L1413.0,751.9  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M1114.1,438.7 L1117.6,442.3  "/>
+            <g transform="translate(1419.8,773.5)" stroke="none" fill="black" font-family="arial"
+                font-size="15.00" text-anchor="middle">
+                <text><tspan font-family="arial"> 4</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter"> </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M183.4,541.6 L1114.1,438.7  "/>
+        </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M1114.1,438.7 L1416.5,755.6  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M183.4,541.6 L190.9,541.6  "/>
+            <g transform="translate(168.5,544.8)" stroke="none" fill="black" font-family="arial"
+                font-size="15.00" text-anchor="end">
+                <text><tspan font-family="arial"> 0</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter"> </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M183.4,497.5 L1114.1,394.5  "/>
+        </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M1114.1,394.5 L1416.5,711.5  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M183.4,497.5 L190.9,497.5  "/>
+            <g transform="translate(168.5,500.7)" stroke="none" fill="black" font-family="arial"
+                font-size="15.00" text-anchor="end">
+                <text><tspan font-family="arial"> 100</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter"> </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M183.4,453.4 L1114.1,350.4  "/>
+        </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M1114.1,350.4 L1416.5,667.3  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M183.4,453.4 L190.9,453.4  "/>
+            <g transform="translate(168.5,456.6)" stroke="none" fill="black" font-family="arial"
+                font-size="15.00" text-anchor="end">
+                <text><tspan font-family="arial"> 200</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter"> </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M183.4,409.3 L1114.1,306.3  "/>
+        </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M1114.1,306.3 L1416.5,623.2  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M183.4,409.3 L190.9,409.3  "/>
+            <g transform="translate(168.5,412.6)" stroke="none" fill="black" font-family="arial"
+                font-size="15.00" text-anchor="end">
+                <text><tspan font-family="arial"> 300</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter"> </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M183.4,365.1 L1114.1,262.2  "/>
+        </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M1114.1,262.2 L1416.5,579.1  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M183.4,365.1 L190.9,365.1  "/>
+            <g transform="translate(168.5,368.4)" stroke="none" fill="black" font-family="arial"
+                font-size="15.00" text-anchor="end">
+                <text><tspan font-family="arial"> 400</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter"> </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M183.4,321.0 L1114.1,218.0  "/>
+        </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M1114.1,218.0 L1416.5,535.0  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M183.4,321.0 L190.9,321.0  "/>
+            <g transform="translate(168.5,324.3)" stroke="none" fill="black" font-family="arial"
+                font-size="15.00" text-anchor="end">
+                <text><tspan font-family="arial"> 500</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter"> </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M183.4,276.9 L1114.1,173.9  "/>
+        </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M1114.1,173.9 L1416.5,490.8  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M183.4,276.9 L190.9,276.9  "/>
+            <g transform="translate(168.5,280.2)" stroke="none" fill="black" font-family="arial"
+                font-size="15.00" text-anchor="end">
+                <text><tspan font-family="arial"> 600</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter"> </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M183.4,232.8 L1114.1,129.8  "/>
+        </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M1114.1,129.8 L1416.5,446.7  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M183.4,232.8 L190.9,232.8  "/>
+            <g transform="translate(168.5,236.1)" stroke="none" fill="black" font-family="arial"
+                font-size="15.00" text-anchor="end">
+                <text><tspan font-family="arial"> 700</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter"> </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M183.4,188.6 L1114.1,85.7  "/>
+        </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M1114.1,85.7 L1416.5,402.6  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M183.4,188.6 L190.9,188.6  "/>
+            <g transform="translate(168.5,191.9)" stroke="none" fill="black" font-family="arial"
+                font-size="15.00" text-anchor="end">
+                <text><tspan font-family="arial"> 800</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter"> </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M183.4,144.5 L1114.1,41.5  "/>
+        </g>
+        <g fill="none" color="gray" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="gray" stroke-dasharray="2,4" class="gridline"
+                d="M1114.1,41.5 L1416.5,358.5  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M183.4,144.5 L190.9,144.5  "/>
+            <g transform="translate(168.5,147.8)" stroke="none" fill="black" font-family="arial"
+                font-size="15.00" text-anchor="end">
+                <text><tspan font-family="arial"> 900</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter"> </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(160, 182, 205)" fill-opacity="0.500000"
+                    points="183.5,541.5 485.9,858.5 1416.5,755.5 1114.1,438.7 183.5,541.5 "/>
+            </g>
+            <path stroke="black"
+                d="M183.5,541.5 L485.9,858.5 L1416.5,755.5 L1114.1,438.7 L183.5,541.5 Z  "/>Z </g>
+        <g id="gnuplot_plot_1">
+            <title>gnuplot_plot_1</title>
+            <g transform="translate(1521.5,55.9)" stroke="none" fill="black" font-family="arial"
+                font-size="15.00" text-anchor="end">
+                <text><tspan font-family="arial">workflow1.dat</tspan></text>
+            </g>
+            <g fill="none" color="black" stroke="currentColor" stroke-width="1.00"
+                stroke-linecap="butt" stroke-linejoin="miter">
+                <g stroke="none" shape-rendering="crispEdges">
+                    <polygon fill="rgb(  0, 158, 115)"
+                        points="1528.5,56.3 1564.0,56.3 1564.0,48.8 1528.5,48.8 "/>
+                </g>
+            </g>
+            <g fill="none" color="black" stroke="currentColor" stroke-width="1.00"
+                stroke-linecap="butt" stroke-linejoin="miter">
+                <path stroke="black"
+                    d="M1528.5,56.3 L1564.0,56.3 L1564.0,48.8 L1528.5,48.8 L1528.5,56.3 Z  "/>
+            </g>
+        </g>
+        <g id="gnuplot_plot_2">
+            <title>gnuplot_plot_2</title>
+            <g fill="none" color="black" stroke="currentColor" stroke-width="1.00"
+                stroke-linecap="butt" stroke-linejoin="miter"> </g>
+        </g>
+        <g id="gnuplot_plot_3">
+            <title>gnuplot_plot_3</title>
+            <g fill="none" color="black" stroke="currentColor" stroke-width="1.00"
+                stroke-linecap="butt" stroke-linejoin="miter"> </g>
+        </g>
+        <g id="gnuplot_plot_4">
+            <title>gnuplot_plot_4</title>
+            <g transform="translate(1521.5,70.9)" stroke="none" fill="black" font-family="arial"
+                font-size="15.00" text-anchor="end">
+                <text><tspan font-family="arial">workflow2.dat</tspan></text>
+            </g>
+            <g fill="none" color="black" stroke="currentColor" stroke-width="1.00"
+                stroke-linecap="butt" stroke-linejoin="miter">
+                <g stroke="none" shape-rendering="crispEdges">
+                    <polygon fill="rgb( 86, 180, 233)"
+                        points="1528.5,71.3 1564.0,71.3 1564.0,63.8 1528.5,63.8 "/>
+                </g>
+            </g>
+            <g fill="none" color="black" stroke="currentColor" stroke-width="1.00"
+                stroke-linecap="butt" stroke-linejoin="miter">
+                <path stroke="black"
+                    d="M1528.5,71.3 L1564.0,71.3 L1564.0,63.8 L1528.5,63.8 L1528.5,71.3 Z  "/>
+            </g>
+        </g>
+        <g id="gnuplot_plot_5">
+            <title>gnuplot_plot_5</title>
+            <g fill="none" color="black" stroke="currentColor" stroke-width="1.00"
+                stroke-linecap="butt" stroke-linejoin="miter"> </g>
+        </g>
+        <g id="gnuplot_plot_6">
+            <title>gnuplot_plot_6</title>
+            <g fill="none" color="black" stroke="currentColor" stroke-width="1.00"
+                stroke-linecap="butt" stroke-linejoin="miter"> </g>
+        </g>
+        <g id="gnuplot_plot_7">
+            <title>gnuplot_plot_7</title>
+            <g transform="translate(1521.5,85.9)" stroke="none" fill="black" font-family="arial"
+                font-size="15.00" text-anchor="end">
+                <text><tspan font-family="arial">workflow3.dat</tspan></text>
+            </g>
+            <g fill="none" color="black" stroke="currentColor" stroke-width="1.00"
+                stroke-linecap="butt" stroke-linejoin="miter">
+                <g stroke="none" shape-rendering="crispEdges">
+                    <polygon fill="rgb(230, 159,   0)"
+                        points="1528.5,86.3 1564.0,86.3 1564.0,78.8 1528.5,78.8 "/>
+                </g>
+            </g>
+            <g fill="none" color="black" stroke="currentColor" stroke-width="1.00"
+                stroke-linecap="butt" stroke-linejoin="miter">
+                <path stroke="black"
+                    d="M1528.5,86.3 L1564.0,86.3 L1564.0,78.8 L1528.5,78.8 L1528.5,86.3 Z  "/>
+            </g>
+        </g>
+        <g id="gnuplot_plot_8">
+            <title>gnuplot_plot_8</title>
+            <g fill="none" color="black" stroke="currentColor" stroke-width="1.00"
+                stroke-linecap="butt" stroke-linejoin="miter"> </g>
+        </g>
+        <g id="gnuplot_plot_9">
+            <title>gnuplot_plot_9</title>
+            <g fill="none" color="black" stroke="currentColor" stroke-width="1.00"
+                stroke-linecap="butt" stroke-linejoin="miter"> </g>
+        </g>
+        <g stroke="none" shape-rendering="crispEdges">
+            <polygon fill="rgb(230, 159,   0)"
+                points="846.5,468.2 846.5,468.2 916.3,460.4 916.3,460.4 "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M846.5,468.2 L916.3,460.4 L846.5,468.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="846.5,468.2 846.5,468.2 916.3,460.4 916.3,460.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M846.5,468.2 L916.3,460.4 L846.5,468.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="846.5,468.2 846.5,468.2 916.3,460.4 916.3,460.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M846.5,468.2 L916.3,460.4 L846.5,468.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="916.3,460.4 916.3,460.4 926.8,471.4 926.8,471.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M916.3,460.4 L926.8,471.4 L916.3,460.4  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="916.3,460.4 916.3,460.4 926.8,471.4 926.8,471.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M916.3,460.4 L926.8,471.4 L916.3,460.4  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="916.3,460.4 916.3,460.4 926.8,471.4 926.8,471.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M916.3,460.4 L926.8,471.4 L916.3,460.4  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="846.5,468.2 916.3,460.4 926.8,471.4 857.0,479.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M846.5,468.2 L857.0,479.1 L926.8,471.4 L916.3,460.4 L846.5,468.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="846.5,468.2 916.3,460.4 926.8,471.4 857.0,479.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M846.5,468.2 L857.0,479.1 L926.8,471.4 L916.3,460.4 L846.5,468.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="846.5,468.2 916.3,460.4 926.8,471.4 857.0,479.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M846.5,468.2 L857.0,479.1 L926.8,471.4 L916.3,460.4 L846.5,468.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="846.5,468.2 846.5,468.2 857.0,479.1 857.0,479.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M846.5,468.2 L857.0,479.1 L846.5,468.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="846.5,468.2 846.5,468.2 857.0,479.1 857.0,479.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M846.5,468.2 L857.0,479.1 L846.5,468.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="846.5,468.2 846.5,468.2 857.0,479.1 857.0,479.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M846.5,468.2 L857.0,479.1 L846.5,468.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="857.0,479.1 857.0,479.1 926.8,471.4 926.8,471.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M857.0,479.1 L926.8,471.4 L857.0,479.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="857.0,479.1 857.0,479.1 926.8,471.4 926.8,471.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M857.0,479.1 L926.8,471.4 L857.0,479.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="857.0,479.1 857.0,479.1 926.8,471.4 926.8,471.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M857.0,479.1 L926.8,471.4 L857.0,479.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="867.4,490.0 867.4,490.0 937.2,482.2 937.2,482.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M867.4,490.0 L937.2,482.3 L937.2,482.2 L867.4,490.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="867.4,490.0 867.4,490.0 937.2,482.2 937.2,482.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M867.4,490.0 L937.2,482.3 L937.2,482.2 L867.4,490.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="867.4,490.0 867.4,490.0 937.2,482.2 937.2,482.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M867.4,490.0 L937.2,482.3 L937.2,482.2 L867.4,490.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="937.2,482.3 937.2,482.2 947.6,493.2 947.6,493.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M937.2,482.3 L947.6,493.2 L937.2,482.2 L937.2,482.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="937.2,482.3 937.2,482.2 947.6,493.2 947.6,493.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M937.2,482.3 L947.6,493.2 L937.2,482.2 L937.2,482.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="937.2,482.3 937.2,482.2 947.6,493.2 947.6,493.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M937.2,482.3 L947.6,493.2 L937.2,482.2 L937.2,482.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="613.9,493.9 613.9,493.9 683.7,486.2 683.7,486.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M613.9,493.9 L683.7,486.2 L613.9,493.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="613.9,493.9 613.9,493.9 683.7,486.2 683.7,486.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M613.9,493.9 L683.7,486.2 L613.9,493.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="613.9,493.9 613.9,493.9 683.7,486.2 683.7,486.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M613.9,493.9 L683.7,486.2 L613.9,493.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="867.4,490.0 937.2,482.2 947.6,493.2 877.8,500.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M867.4,490.0 L877.8,500.9 L947.6,493.2 L937.2,482.2 L867.4,490.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="867.4,490.0 937.2,482.2 947.6,493.2 877.8,500.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M867.4,490.0 L877.8,500.9 L947.6,493.2 L937.2,482.2 L867.4,490.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="867.4,490.0 937.2,482.2 947.6,493.2 877.8,500.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M867.4,490.0 L877.8,500.9 L947.6,493.2 L937.2,482.2 L867.4,490.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="683.7,486.2 683.7,486.2 694.2,497.1 694.2,497.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M683.7,486.2 L694.2,497.1 L683.7,486.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="683.7,486.2 683.7,486.2 694.2,497.1 694.2,497.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M683.7,486.2 L694.2,497.1 L683.7,486.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="683.7,486.2 683.7,486.2 694.2,497.1 694.2,497.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M683.7,486.2 L694.2,497.1 L683.7,486.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="867.4,490.0 867.4,490.0 877.8,500.9 877.8,501.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M867.4,490.0 L877.8,501.0 L877.8,500.9 L867.4,490.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="867.4,490.0 867.4,490.0 877.8,500.9 877.8,501.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M867.4,490.0 L877.8,501.0 L877.8,500.9 L867.4,490.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="867.4,490.0 867.4,490.0 877.8,500.9 877.8,501.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M867.4,490.0 L877.8,501.0 L877.8,500.9 L867.4,490.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="613.9,493.9 683.7,486.2 694.2,497.1 624.4,504.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M613.9,493.9 L624.4,504.8 L694.2,497.1 L683.7,486.2 L613.9,493.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="613.9,493.9 683.7,486.2 694.2,497.1 624.4,504.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M613.9,493.9 L624.4,504.8 L694.2,497.1 L683.7,486.2 L613.9,493.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="613.9,493.9 683.7,486.2 694.2,497.1 624.4,504.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M613.9,493.9 L624.4,504.8 L694.2,497.1 L683.7,486.2 L613.9,493.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="877.8,501.0 877.8,500.9 947.6,493.2 947.6,493.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M877.8,501.0 L947.6,493.2 L877.8,500.9 L877.8,501.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="877.8,501.0 877.8,500.9 947.6,493.2 947.6,493.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M877.8,501.0 L947.6,493.2 L877.8,500.9 L877.8,501.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="877.8,501.0 877.8,500.9 947.6,493.2 947.6,493.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M877.8,501.0 L947.6,493.2 L877.8,500.9 L877.8,501.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="613.9,493.9 613.9,493.9 624.4,504.8 624.4,504.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M613.9,493.9 L624.4,504.8 L613.9,493.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="613.9,493.9 613.9,493.9 624.4,504.8 624.4,504.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M613.9,493.9 L624.4,504.8 L613.9,493.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="613.9,493.9 613.9,493.9 624.4,504.8 624.4,504.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M613.9,493.9 L624.4,504.8 L613.9,493.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="624.4,504.8 624.4,504.8 694.2,497.1 694.2,497.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M624.4,504.8 L694.2,497.1 L624.4,504.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="624.4,504.8 624.4,504.8 694.2,497.1 694.2,497.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M624.4,504.8 L694.2,497.1 L624.4,504.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="624.4,504.8 624.4,504.8 694.2,497.1 694.2,497.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M624.4,504.8 L694.2,497.1 L624.4,504.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="888.2,511.9 888.2,511.9 958.0,504.2 958.0,504.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M888.2,511.9 L958.0,504.2 L888.2,511.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="888.2,511.9 888.2,511.9 958.0,504.2 958.0,504.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M888.2,511.9 L958.0,504.2 L888.2,511.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="888.2,511.9 888.2,511.9 958.0,504.2 958.0,504.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M888.2,511.9 L958.0,504.2 L888.2,511.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="958.0,504.2 958.0,504.2 968.5,515.1 968.5,515.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M958.0,504.2 L968.5,515.1 L958.0,504.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="958.0,504.2 958.0,504.2 968.5,515.1 968.5,515.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M958.0,504.2 L968.5,515.1 L958.0,504.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="958.0,504.2 958.0,504.2 968.5,515.1 968.5,515.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M958.0,504.2 L968.5,515.1 L958.0,504.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="634.8,515.8 634.8,515.7 704.6,508.0 704.6,508.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M634.8,515.8 L704.6,508.1 L704.6,508.0 L634.8,515.7 L634.8,515.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="634.8,515.8 634.8,515.7 704.6,508.0 704.6,508.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M634.8,515.8 L704.6,508.1 L704.6,508.0 L634.8,515.7 L634.8,515.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="634.8,515.8 634.8,515.7 704.6,508.0 704.6,508.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M634.8,515.8 L704.6,508.1 L704.6,508.0 L634.8,515.7 L634.8,515.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="888.2,511.9 958.0,504.2 968.5,515.1 898.7,522.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M888.2,511.9 L898.7,522.8 L968.5,515.1 L958.0,504.2 L888.2,511.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="888.2,511.9 958.0,504.2 968.5,515.1 898.7,522.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M888.2,511.9 L898.7,522.8 L968.5,515.1 L958.0,504.2 L888.2,511.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="888.2,511.9 958.0,504.2 968.5,515.1 898.7,522.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M888.2,511.9 L898.7,522.8 L968.5,515.1 L958.0,504.2 L888.2,511.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="704.6,508.1 704.6,508.0 715.0,518.9 715.0,519.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M704.6,508.1 L715.0,519.0 L715.0,518.9 L704.6,508.0 L704.6,508.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="704.6,508.1 704.6,508.0 715.0,518.9 715.0,519.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M704.6,508.1 L715.0,519.0 L715.0,518.9 L704.6,508.0 L704.6,508.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="704.6,508.1 704.6,508.0 715.0,518.9 715.0,519.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M704.6,508.1 L715.0,519.0 L715.0,518.9 L704.6,508.0 L704.6,508.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="381.2,519.7 381.2,519.6 451.0,511.9 451.0,511.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M381.2,519.7 L451.0,511.9 L381.2,519.6 L381.2,519.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="381.2,519.7 381.2,519.6 451.0,511.9 451.0,511.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M381.2,519.7 L451.0,511.9 L381.2,519.6 L381.2,519.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="381.2,519.7 381.2,519.6 451.0,511.9 451.0,511.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M381.2,519.7 L451.0,511.9 L381.2,519.6 L381.2,519.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="888.2,511.9 888.2,511.9 898.7,522.8 898.7,522.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M888.2,511.9 L898.7,522.8 L888.2,511.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="888.2,511.9 888.2,511.9 898.7,522.8 898.7,522.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M888.2,511.9 L898.7,522.8 L888.2,511.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="888.2,511.9 888.2,511.9 898.7,522.8 898.7,522.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M888.2,511.9 L898.7,522.8 L888.2,511.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="634.8,515.7 704.6,508.0 715.0,518.9 645.2,526.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M634.8,515.7 L645.2,526.6 L715.0,518.9 L704.6,508.0 L634.8,515.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="634.8,515.7 704.6,508.0 715.0,518.9 645.2,526.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M634.8,515.7 L645.2,526.6 L715.0,518.9 L704.6,508.0 L634.8,515.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="634.8,515.7 704.6,508.0 715.0,518.9 645.2,526.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M634.8,515.7 L645.2,526.6 L715.0,518.9 L704.6,508.0 L634.8,515.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="451.0,511.9 451.0,511.9 461.5,522.9 461.5,522.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M451.0,511.9 L461.5,522.9 L451.0,511.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="451.0,511.9 451.0,511.9 461.5,522.9 461.5,522.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M451.0,511.9 L461.5,522.9 L451.0,511.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="451.0,511.9 451.0,511.9 461.5,522.9 461.5,522.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M451.0,511.9 L461.5,522.9 L451.0,511.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="898.7,522.8 898.7,522.8 968.5,515.1 968.5,515.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M898.7,522.8 L968.5,515.1 L898.7,522.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="898.7,522.8 898.7,522.8 968.5,515.1 968.5,515.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M898.7,522.8 L968.5,515.1 L898.7,522.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="898.7,522.8 898.7,522.8 968.5,515.1 968.5,515.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M898.7,522.8 L968.5,515.1 L898.7,522.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="634.8,515.8 634.8,515.7 645.2,526.6 645.2,526.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M634.8,515.8 L645.2,526.7 L645.2,526.6 L634.8,515.7 L634.8,515.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="634.8,515.8 634.8,515.7 645.2,526.6 645.2,526.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M634.8,515.8 L645.2,526.7 L645.2,526.6 L634.8,515.7 L634.8,515.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="634.8,515.8 634.8,515.7 645.2,526.6 645.2,526.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M634.8,515.8 L645.2,526.7 L645.2,526.6 L634.8,515.7 L634.8,515.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="381.2,519.6 451.0,511.9 461.5,522.9 391.7,530.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M381.2,519.6 L391.7,530.6 L461.5,522.9 L451.0,511.9 L381.2,519.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="381.2,519.6 451.0,511.9 461.5,522.9 391.7,530.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M381.2,519.6 L391.7,530.6 L461.5,522.9 L451.0,511.9 L381.2,519.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="381.2,519.6 451.0,511.9 461.5,522.9 391.7,530.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M381.2,519.6 L391.7,530.6 L461.5,522.9 L451.0,511.9 L381.2,519.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="645.2,526.7 645.2,526.6 715.0,518.9 715.0,519.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M645.2,526.7 L715.0,519.0 L715.0,518.9 L645.2,526.6 L645.2,526.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="645.2,526.7 645.2,526.6 715.0,518.9 715.0,519.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M645.2,526.7 L715.0,519.0 L715.0,518.9 L645.2,526.6 L645.2,526.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="645.2,526.7 645.2,526.6 715.0,518.9 715.0,519.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M645.2,526.7 L715.0,519.0 L715.0,518.9 L645.2,526.6 L645.2,526.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="381.2,519.7 381.2,519.6 391.7,530.6 391.7,530.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M381.2,519.7 L391.7,530.6 L381.2,519.6 L381.2,519.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="381.2,519.7 381.2,519.6 391.7,530.6 391.7,530.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M381.2,519.7 L391.7,530.6 L381.2,519.6 L381.2,519.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="381.2,519.7 381.2,519.6 391.7,530.6 391.7,530.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M381.2,519.7 L391.7,530.6 L381.2,519.6 L381.2,519.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="391.7,530.6 391.7,530.6 461.5,522.9 461.5,522.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M391.7,530.6 L461.5,522.9 L391.7,530.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="391.7,530.6 391.7,530.6 461.5,522.9 461.5,522.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M391.7,530.6 L461.5,522.9 L391.7,530.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="391.7,530.6 391.7,530.6 461.5,522.9 461.5,522.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M391.7,530.6 L461.5,522.9 L391.7,530.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="909.1,533.7 909.1,530.8 978.9,523.1 978.9,526.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M909.1,533.7 L978.9,526.0 L978.9,523.1 L909.1,530.8 L909.1,533.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="909.1,533.7 909.1,530.8 978.9,523.1 978.9,526.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M909.1,533.7 L978.9,526.0 L978.9,523.1 L909.1,530.8 L909.1,533.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="909.1,533.7 909.1,530.8 978.9,523.1 978.9,526.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M909.1,533.7 L978.9,526.0 L978.9,523.1 L909.1,530.8 L909.1,533.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="978.9,526.0 978.9,523.1 989.3,534.1 989.3,536.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M978.9,526.0 L989.3,536.9 L989.3,534.1 L978.9,523.1 L978.9,526.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="978.9,526.0 978.9,523.1 989.3,534.1 989.3,536.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M978.9,526.0 L989.3,536.9 L989.3,534.1 L978.9,523.1 L978.9,526.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="978.9,526.0 978.9,523.1 989.3,534.1 989.3,536.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M978.9,526.0 L989.3,536.9 L989.3,534.1 L978.9,523.1 L978.9,526.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="655.6,537.6 655.6,537.6 725.5,529.9 725.5,529.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M655.6,537.6 L725.5,529.9 L655.6,537.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="655.6,537.6 655.6,537.6 725.5,529.9 725.5,529.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M655.6,537.6 L725.5,529.9 L655.6,537.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="655.6,537.6 655.6,537.6 725.5,529.9 725.5,529.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M655.6,537.6 L725.5,529.9 L655.6,537.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="909.1,530.8 978.9,523.1 989.3,534.1 919.5,541.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M909.1,530.8 L919.5,541.8 L989.3,534.1 L978.9,523.1 L909.1,530.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="909.1,530.8 978.9,523.1 989.3,534.1 919.5,541.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M909.1,530.8 L919.5,541.8 L989.3,534.1 L978.9,523.1 L909.1,530.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="909.1,530.8 978.9,523.1 989.3,534.1 919.5,541.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M909.1,530.8 L919.5,541.8 L989.3,534.1 L978.9,523.1 L909.1,530.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="725.5,529.9 725.5,529.9 735.9,540.8 735.9,540.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M725.5,529.9 L735.9,540.8 L725.5,529.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="725.5,529.9 725.5,529.9 735.9,540.8 735.9,540.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M725.5,529.9 L735.9,540.8 L725.5,529.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="725.5,529.9 725.5,529.9 735.9,540.8 735.9,540.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M725.5,529.9 L735.9,540.8 L725.5,529.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="402.1,541.5 402.1,541.5 471.9,533.8 471.9,533.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M402.1,541.5 L471.9,533.8 L402.1,541.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="402.1,541.5 402.1,541.5 471.9,533.8 471.9,533.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M402.1,541.5 L471.9,533.8 L402.1,541.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="402.1,541.5 402.1,541.5 471.9,533.8 471.9,533.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M402.1,541.5 L471.9,533.8 L402.1,541.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="909.1,533.7 909.1,530.8 919.5,541.8 919.5,544.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M909.1,533.7 L919.5,544.7 L919.5,541.8 L909.1,530.8 L909.1,533.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="909.1,533.7 909.1,530.8 919.5,541.8 919.5,544.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M909.1,533.7 L919.5,544.7 L919.5,541.8 L909.1,530.8 L909.1,533.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="909.1,533.7 909.1,530.8 919.5,541.8 919.5,544.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M909.1,533.7 L919.5,544.7 L919.5,541.8 L909.1,530.8 L909.1,533.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="655.6,537.6 725.5,529.9 735.9,540.8 666.1,548.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M655.6,537.6 L666.1,548.6 L735.9,540.8 L725.5,529.9 L655.6,537.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="655.6,537.6 725.5,529.9 735.9,540.8 666.1,548.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M655.6,537.6 L666.1,548.6 L735.9,540.8 L725.5,529.9 L655.6,537.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="655.6,537.6 725.5,529.9 735.9,540.8 666.1,548.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M655.6,537.6 L666.1,548.6 L735.9,540.8 L725.5,529.9 L655.6,537.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="471.9,533.8 471.9,533.8 482.3,544.7 482.3,544.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M471.9,533.8 L482.3,544.7 L471.9,533.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="471.9,533.8 471.9,533.8 482.3,544.7 482.3,544.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M471.9,533.8 L482.3,544.7 L471.9,533.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="471.9,533.8 471.9,533.8 482.3,544.7 482.3,544.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M471.9,533.8 L482.3,544.7 L471.9,533.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="919.5,544.7 919.5,541.8 989.3,534.1 989.3,536.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M919.5,544.7 L989.3,536.9 L989.3,534.1 L919.5,541.8 L919.5,544.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="919.5,544.7 919.5,541.8 989.3,534.1 989.3,536.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M919.5,544.7 L989.3,536.9 L989.3,534.1 L919.5,541.8 L919.5,544.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="919.5,544.7 919.5,541.8 989.3,534.1 989.3,536.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M919.5,544.7 L989.3,536.9 L989.3,534.1 L919.5,541.8 L919.5,544.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="655.6,537.6 655.6,537.6 666.1,548.6 666.1,548.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M655.6,537.6 L666.1,548.6 L655.6,537.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="655.6,537.6 655.6,537.6 666.1,548.6 666.1,548.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M655.6,537.6 L666.1,548.6 L655.6,537.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="655.6,537.6 655.6,537.6 666.1,548.6 666.1,548.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M655.6,537.6 L666.1,548.6 L655.6,537.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="402.1,541.5 471.9,533.8 482.3,544.7 412.5,552.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M402.1,541.5 L412.5,552.4 L482.3,544.7 L471.9,533.8 L402.1,541.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="402.1,541.5 471.9,533.8 482.3,544.7 412.5,552.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M402.1,541.5 L412.5,552.4 L482.3,544.7 L471.9,533.8 L402.1,541.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="402.1,541.5 471.9,533.8 482.3,544.7 412.5,552.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M402.1,541.5 L412.5,552.4 L482.3,544.7 L471.9,533.8 L402.1,541.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="666.1,548.6 666.1,548.6 735.9,540.8 735.9,540.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M666.1,548.6 L735.9,540.8 L666.1,548.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="666.1,548.6 666.1,548.6 735.9,540.8 735.9,540.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M666.1,548.6 L735.9,540.8 L666.1,548.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="666.1,548.6 666.1,548.6 735.9,540.8 735.9,540.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M666.1,548.6 L735.9,540.8 L666.1,548.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="402.1,541.5 402.1,541.5 412.5,552.4 412.5,552.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M402.1,541.5 L412.5,552.4 L402.1,541.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="402.1,541.5 402.1,541.5 412.5,552.4 412.5,552.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M402.1,541.5 L412.5,552.4 L402.1,541.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="402.1,541.5 402.1,541.5 412.5,552.4 412.5,552.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M402.1,541.5 L412.5,552.4 L402.1,541.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="412.5,552.4 412.5,552.4 482.3,544.7 482.3,544.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M412.5,552.4 L482.3,544.7 L412.5,552.4  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="412.5,552.4 412.5,552.4 482.3,544.7 482.3,544.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M412.5,552.4 L482.3,544.7 L412.5,552.4  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="412.5,552.4 412.5,552.4 482.3,544.7 482.3,544.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M412.5,552.4 L482.3,544.7 L412.5,552.4  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="930.0,555.6 930.0,189.0 999.8,181.2 999.8,547.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M930.0,555.6 L999.8,547.9 L999.8,181.2 L930.0,189.0 L930.0,555.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="930.0,555.6 930.0,189.0 999.8,181.2 999.8,547.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M930.0,555.6 L999.8,547.9 L999.8,181.2 L930.0,189.0 L930.0,555.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="930.0,555.6 930.0,189.0 999.8,181.2 999.8,547.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M930.0,555.6 L999.8,547.9 L999.8,181.2 L930.0,189.0 L930.0,555.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="999.8,547.9 999.8,181.2 1010.2,192.2 1010.2,558.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M999.8,547.9 L1010.2,558.8 L1010.2,192.2 L999.8,181.2 L999.8,547.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="999.8,547.9 999.8,181.2 1010.2,192.2 1010.2,558.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M999.8,547.9 L1010.2,558.8 L1010.2,192.2 L999.8,181.2 L999.8,547.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="999.8,547.9 999.8,181.2 1010.2,192.2 1010.2,558.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M999.8,547.9 L1010.2,558.8 L1010.2,192.2 L999.8,181.2 L999.8,547.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="676.5,559.5 676.5,556.6 746.3,548.9 746.3,551.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M676.5,559.5 L746.3,551.8 L746.3,548.9 L676.5,556.6 L676.5,559.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="676.5,559.5 676.5,556.6 746.3,548.9 746.3,551.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M676.5,559.5 L746.3,551.8 L746.3,548.9 L676.5,556.6 L676.5,559.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="676.5,559.5 676.5,556.6 746.3,548.9 746.3,551.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M676.5,559.5 L746.3,551.8 L746.3,548.9 L676.5,556.6 L676.5,559.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="930.0,189.0 999.8,181.2 1010.2,192.2 940.4,199.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M930.0,189.0 L940.4,199.9 L1010.2,192.2 L999.8,181.2 L930.0,189.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="930.0,189.0 999.8,181.2 1010.2,192.2 940.4,199.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M930.0,189.0 L940.4,199.9 L1010.2,192.2 L999.8,181.2 L930.0,189.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="930.0,189.0 999.8,181.2 1010.2,192.2 940.4,199.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M930.0,189.0 L940.4,199.9 L1010.2,192.2 L999.8,181.2 L930.0,189.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="746.3,551.8 746.3,548.9 756.7,559.8 756.7,562.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M746.3,551.8 L756.7,562.7 L756.7,559.8 L746.3,548.9 L746.3,551.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="746.3,551.8 746.3,548.9 756.7,559.8 756.7,562.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M746.3,551.8 L756.7,562.7 L756.7,559.8 L746.3,548.9 L746.3,551.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="746.3,551.8 746.3,548.9 756.7,559.8 756.7,562.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M746.3,551.8 L756.7,562.7 L756.7,559.8 L746.3,548.9 L746.3,551.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="423.0,563.4 423.0,563.3 492.8,555.6 492.8,555.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M423.0,563.4 L492.8,555.7 L492.8,555.6 L423.0,563.3 L423.0,563.4  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="423.0,563.4 423.0,563.3 492.8,555.6 492.8,555.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M423.0,563.4 L492.8,555.7 L492.8,555.6 L423.0,563.3 L423.0,563.4  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="423.0,563.4 423.0,563.3 492.8,555.6 492.8,555.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M423.0,563.4 L492.8,555.7 L492.8,555.6 L423.0,563.3 L423.0,563.4  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="930.0,555.6 930.0,189.0 940.4,199.9 940.4,566.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M930.0,555.6 L940.4,566.5 L940.4,199.9 L930.0,189.0 L930.0,555.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="930.0,555.6 930.0,189.0 940.4,199.9 940.4,566.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M930.0,555.6 L940.4,566.5 L940.4,199.9 L930.0,189.0 L930.0,555.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="930.0,555.6 930.0,189.0 940.4,199.9 940.4,566.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M930.0,555.6 L940.4,566.5 L940.4,199.9 L930.0,189.0 L930.0,555.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="676.5,556.6 746.3,548.9 756.7,559.8 686.9,567.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M676.5,556.6 L686.9,567.5 L756.7,559.8 L746.3,548.9 L676.5,556.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="676.5,556.6 746.3,548.9 756.7,559.8 686.9,567.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M676.5,556.6 L686.9,567.5 L756.7,559.8 L746.3,548.9 L676.5,556.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="676.5,556.6 746.3,548.9 756.7,559.8 686.9,567.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M676.5,556.6 L686.9,567.5 L756.7,559.8 L746.3,548.9 L676.5,556.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="492.8,555.7 492.8,555.6 503.2,566.5 503.2,566.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M492.8,555.7 L503.2,566.6 L503.2,566.5 L492.8,555.6 L492.8,555.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="492.8,555.7 492.8,555.6 503.2,566.5 503.2,566.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M492.8,555.7 L503.2,566.6 L503.2,566.5 L492.8,555.6 L492.8,555.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="492.8,555.7 492.8,555.6 503.2,566.5 503.2,566.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M492.8,555.7 L503.2,566.6 L503.2,566.5 L492.8,555.6 L492.8,555.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="940.4,566.5 940.4,199.9 1010.2,192.2 1010.2,558.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M940.4,566.5 L1010.2,558.8 L1010.2,192.2 L940.4,199.9 L940.4,566.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="940.4,566.5 940.4,199.9 1010.2,192.2 1010.2,558.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M940.4,566.5 L1010.2,558.8 L1010.2,192.2 L940.4,199.9 L940.4,566.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="940.4,566.5 940.4,199.9 1010.2,192.2 1010.2,558.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M940.4,566.5 L1010.2,558.8 L1010.2,192.2 L940.4,199.9 L940.4,566.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="676.5,559.5 676.5,556.6 686.9,567.5 686.9,570.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M676.5,559.5 L686.9,570.4 L686.9,567.5 L676.5,556.6 L676.5,559.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="676.5,559.5 676.5,556.6 686.9,567.5 686.9,570.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M676.5,559.5 L686.9,570.4 L686.9,567.5 L676.5,556.6 L676.5,559.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="676.5,559.5 676.5,556.6 686.9,567.5 686.9,570.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M676.5,559.5 L686.9,570.4 L686.9,567.5 L676.5,556.6 L676.5,559.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="423.0,563.3 492.8,555.6 503.2,566.5 433.4,574.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M423.0,563.3 L433.4,574.2 L503.2,566.5 L492.8,555.6 L423.0,563.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="423.0,563.3 492.8,555.6 503.2,566.5 433.4,574.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M423.0,563.3 L433.4,574.2 L503.2,566.5 L492.8,555.6 L423.0,563.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="423.0,563.3 492.8,555.6 503.2,566.5 433.4,574.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M423.0,563.3 L433.4,574.2 L503.2,566.5 L492.8,555.6 L423.0,563.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="686.9,570.4 686.9,567.5 756.7,559.8 756.7,562.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M686.9,570.4 L756.7,562.7 L756.7,559.8 L686.9,567.5 L686.9,570.4  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="686.9,570.4 686.9,567.5 756.7,559.8 756.7,562.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M686.9,570.4 L756.7,562.7 L756.7,559.8 L686.9,567.5 L686.9,570.4  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="686.9,570.4 686.9,567.5 756.7,559.8 756.7,562.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M686.9,570.4 L756.7,562.7 L756.7,559.8 L686.9,567.5 L686.9,570.4  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="423.0,563.4 423.0,563.3 433.4,574.2 433.4,574.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M423.0,563.4 L433.4,574.3 L433.4,574.2 L423.0,563.3 L423.0,563.4  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="423.0,563.4 423.0,563.3 433.4,574.2 433.4,574.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M423.0,563.4 L433.4,574.3 L433.4,574.2 L423.0,563.3 L423.0,563.4  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="423.0,563.4 423.0,563.3 433.4,574.2 433.4,574.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M423.0,563.4 L433.4,574.3 L433.4,574.2 L423.0,563.3 L423.0,563.4  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="433.4,574.3 433.4,574.2 503.2,566.5 503.2,566.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M433.4,574.3 L503.2,566.6 L503.2,566.5 L433.4,574.2 L433.4,574.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="433.4,574.3 433.4,574.2 503.2,566.5 503.2,566.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M433.4,574.3 L503.2,566.6 L503.2,566.5 L433.4,574.2 L433.4,574.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="433.4,574.3 433.4,574.2 503.2,566.5 503.2,566.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M433.4,574.3 L503.2,566.6 L503.2,566.5 L433.4,574.2 L433.4,574.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="950.8,577.5 950.8,559.8 1020.6,552.0 1020.6,569.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M950.8,577.5 L1020.6,569.7 L1020.6,552.0 L950.8,559.8 L950.8,577.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="950.8,577.5 950.8,559.8 1020.6,552.0 1020.6,569.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M950.8,577.5 L1020.6,569.7 L1020.6,552.0 L950.8,559.8 L950.8,577.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="950.8,577.5 950.8,559.8 1020.6,552.0 1020.6,569.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M950.8,577.5 L1020.6,569.7 L1020.6,552.0 L950.8,559.8 L950.8,577.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1020.6,569.7 1020.6,552.0 1031.0,563.0 1031.0,580.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1020.6,569.7 L1031.0,580.7 L1031.0,563.0 L1020.6,552.0 L1020.6,569.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1020.6,569.7 1020.6,552.0 1031.0,563.0 1031.0,580.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1020.6,569.7 L1031.0,580.7 L1031.0,563.0 L1020.6,552.0 L1020.6,569.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1020.6,569.7 1020.6,552.0 1031.0,563.0 1031.0,580.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1020.6,569.7 L1031.0,580.7 L1031.0,563.0 L1020.6,552.0 L1020.6,569.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="697.4,581.3 697.4,214.7 767.2,207.0 767.2,573.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M697.4,581.3 L767.2,573.6 L767.2,207.0 L697.4,214.7 L697.4,581.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="697.4,581.3 697.4,214.7 767.2,207.0 767.2,573.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M697.4,581.3 L767.2,573.6 L767.2,207.0 L697.4,214.7 L697.4,581.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="697.4,581.3 697.4,214.7 767.2,207.0 767.2,573.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M697.4,581.3 L767.2,573.6 L767.2,207.0 L697.4,214.7 L697.4,581.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="950.8,559.8 1020.6,552.0 1031.0,563.0 961.2,570.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M950.8,559.8 L961.2,570.7 L1031.0,563.0 L1020.6,552.0 L950.8,559.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="950.8,559.8 1020.6,552.0 1031.0,563.0 961.2,570.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M950.8,559.8 L961.2,570.7 L1031.0,563.0 L1020.6,552.0 L950.8,559.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="950.8,559.8 1020.6,552.0 1031.0,563.0 961.2,570.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M950.8,559.8 L961.2,570.7 L1031.0,563.0 L1020.6,552.0 L950.8,559.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="767.2,573.6 767.2,207.0 777.6,217.9 777.6,584.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M767.2,573.6 L777.6,584.6 L777.6,217.9 L767.2,207.0 L767.2,573.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="767.2,573.6 767.2,207.0 777.6,217.9 777.6,584.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M767.2,573.6 L777.6,584.6 L777.6,217.9 L767.2,207.0 L767.2,573.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="767.2,573.6 767.2,207.0 777.6,217.9 777.6,584.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M767.2,573.6 L777.6,584.6 L777.6,217.9 L767.2,207.0 L767.2,573.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="443.8,585.2 443.8,574.1 513.6,566.4 513.6,577.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M443.8,585.2 L513.6,577.5 L513.6,566.4 L443.8,574.1 L443.8,585.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="443.8,585.2 443.8,574.1 513.6,566.4 513.6,577.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M443.8,585.2 L513.6,577.5 L513.6,566.4 L443.8,574.1 L443.8,585.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="443.8,585.2 443.8,574.1 513.6,566.4 513.6,577.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M443.8,585.2 L513.6,577.5 L513.6,566.4 L443.8,574.1 L443.8,585.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="950.8,577.5 950.8,559.8 961.2,570.7 961.2,588.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M950.8,577.5 L961.2,588.4 L961.2,570.7 L950.8,559.8 L950.8,577.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="950.8,577.5 950.8,559.8 961.2,570.7 961.2,588.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M950.8,577.5 L961.2,588.4 L961.2,570.7 L950.8,559.8 L950.8,577.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="950.8,577.5 950.8,559.8 961.2,570.7 961.2,588.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M950.8,577.5 L961.2,588.4 L961.2,570.7 L950.8,559.8 L950.8,577.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="697.4,214.7 767.2,207.0 777.6,217.9 707.8,225.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M697.4,214.7 L707.8,225.6 L777.6,217.9 L767.2,207.0 L697.4,214.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="697.4,214.7 767.2,207.0 777.6,217.9 707.8,225.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M697.4,214.7 L707.8,225.6 L777.6,217.9 L767.2,207.0 L697.4,214.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="697.4,214.7 767.2,207.0 777.6,217.9 707.8,225.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M697.4,214.7 L707.8,225.6 L777.6,217.9 L767.2,207.0 L697.4,214.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="513.6,577.5 513.6,566.4 524.0,577.3 524.0,588.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M513.6,577.5 L524.0,588.4 L524.0,577.3 L513.6,566.4 L513.6,577.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="513.6,577.5 513.6,566.4 524.0,577.3 524.0,588.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M513.6,577.5 L524.0,588.4 L524.0,577.3 L513.6,566.4 L513.6,577.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="513.6,577.5 513.6,566.4 524.0,577.3 524.0,588.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M513.6,577.5 L524.0,588.4 L524.0,577.3 L513.6,566.4 L513.6,577.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="961.2,588.4 961.2,570.7 1031.0,563.0 1031.0,580.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M961.2,588.4 L1031.0,580.7 L1031.0,563.0 L961.2,570.7 L961.2,588.4  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="961.2,588.4 961.2,570.7 1031.0,563.0 1031.0,580.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M961.2,588.4 L1031.0,580.7 L1031.0,563.0 L961.2,570.7 L961.2,588.4  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="961.2,588.4 961.2,570.7 1031.0,563.0 1031.0,580.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M961.2,588.4 L1031.0,580.7 L1031.0,563.0 L961.2,570.7 L961.2,588.4  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="697.4,581.3 697.4,214.7 707.8,225.6 707.8,592.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M697.4,581.3 L707.8,592.3 L707.8,225.6 L697.4,214.7 L697.4,581.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="697.4,581.3 697.4,214.7 707.8,225.6 707.8,592.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M697.4,581.3 L707.8,592.3 L707.8,225.6 L697.4,214.7 L697.4,581.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="697.4,581.3 697.4,214.7 707.8,225.6 707.8,592.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M697.4,581.3 L707.8,592.3 L707.8,225.6 L697.4,214.7 L697.4,581.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="443.8,574.1 513.6,566.4 524.0,577.3 454.2,585.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M443.8,574.1 L454.2,585.0 L524.0,577.3 L513.6,566.4 L443.8,574.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="443.8,574.1 513.6,566.4 524.0,577.3 454.2,585.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M443.8,574.1 L454.2,585.0 L524.0,577.3 L513.6,566.4 L443.8,574.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="443.8,574.1 513.6,566.4 524.0,577.3 454.2,585.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M443.8,574.1 L454.2,585.0 L524.0,577.3 L513.6,566.4 L443.8,574.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="707.8,592.3 707.8,225.6 777.6,217.9 777.6,584.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M707.8,592.3 L777.6,584.6 L777.6,217.9 L707.8,225.6 L707.8,592.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="707.8,592.3 707.8,225.6 777.6,217.9 777.6,584.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M707.8,592.3 L777.6,584.6 L777.6,217.9 L707.8,225.6 L707.8,592.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="707.8,592.3 707.8,225.6 777.6,217.9 777.6,584.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M707.8,592.3 L777.6,584.6 L777.6,217.9 L707.8,225.6 L707.8,592.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="443.8,585.2 443.8,574.1 454.2,585.0 454.2,596.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M443.8,585.2 L454.2,596.2 L454.2,585.0 L443.8,574.1 L443.8,585.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="443.8,585.2 443.8,574.1 454.2,585.0 454.2,596.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M443.8,585.2 L454.2,596.2 L454.2,585.0 L443.8,574.1 L443.8,585.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="443.8,585.2 443.8,574.1 454.2,585.0 454.2,596.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M443.8,585.2 L454.2,596.2 L454.2,585.0 L443.8,574.1 L443.8,585.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="454.2,596.2 454.2,585.0 524.0,577.3 524.0,588.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M454.2,596.2 L524.0,588.4 L524.0,577.3 L454.2,585.0 L454.2,596.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="454.2,596.2 454.2,585.0 524.0,577.3 524.0,588.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M454.2,596.2 L524.0,588.4 L524.0,577.3 L454.2,585.0 L454.2,596.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="454.2,596.2 454.2,585.0 524.0,577.3 524.0,588.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M454.2,596.2 L524.0,588.4 L524.0,577.3 L454.2,585.0 L454.2,596.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="971.7,599.3 971.7,577.2 1041.5,569.5 1041.5,591.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M971.7,599.3 L1041.5,591.6 L1041.5,569.5 L971.7,577.2 L971.7,599.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="971.7,599.3 971.7,577.2 1041.5,569.5 1041.5,591.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M971.7,599.3 L1041.5,591.6 L1041.5,569.5 L971.7,577.2 L971.7,599.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="971.7,599.3 971.7,577.2 1041.5,569.5 1041.5,591.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M971.7,599.3 L1041.5,591.6 L1041.5,569.5 L971.7,577.2 L971.7,599.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1041.5,591.6 1041.5,569.5 1051.9,580.4 1051.9,602.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1041.5,591.6 L1051.9,602.5 L1051.9,580.4 L1041.5,569.5 L1041.5,591.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1041.5,591.6 1041.5,569.5 1051.9,580.4 1051.9,602.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1041.5,591.6 L1051.9,602.5 L1051.9,580.4 L1041.5,569.5 L1041.5,591.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1041.5,591.6 1041.5,569.5 1051.9,580.4 1051.9,602.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1041.5,591.6 L1051.9,602.5 L1051.9,580.4 L1041.5,569.5 L1041.5,591.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="718.2,603.2 718.2,585.5 788.0,577.8 788.0,595.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M718.2,603.2 L788.0,595.5 L788.0,577.8 L718.2,585.5 L718.2,603.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="718.2,603.2 718.2,585.5 788.0,577.8 788.0,595.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M718.2,603.2 L788.0,595.5 L788.0,577.8 L718.2,585.5 L718.2,603.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="718.2,603.2 718.2,585.5 788.0,577.8 788.0,595.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M718.2,603.2 L788.0,595.5 L788.0,577.8 L718.2,585.5 L718.2,603.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="971.7,577.2 1041.5,569.5 1051.9,580.4 982.1,588.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M971.7,577.2 L982.1,588.1 L1051.9,580.4 L1041.5,569.5 L971.7,577.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="971.7,577.2 1041.5,569.5 1051.9,580.4 982.1,588.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M971.7,577.2 L982.1,588.1 L1051.9,580.4 L1041.5,569.5 L971.7,577.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="971.7,577.2 1041.5,569.5 1051.9,580.4 982.1,588.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M971.7,577.2 L982.1,588.1 L1051.9,580.4 L1041.5,569.5 L971.7,577.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="788.0,595.5 788.0,577.8 798.5,588.7 798.5,606.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M788.0,595.5 L798.5,606.4 L798.5,588.7 L788.0,577.8 L788.0,595.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="788.0,595.5 788.0,577.8 798.5,588.7 798.5,606.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M788.0,595.5 L798.5,606.4 L798.5,588.7 L788.0,577.8 L788.0,595.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="788.0,595.5 788.0,577.8 798.5,588.7 798.5,606.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M788.0,595.5 L798.5,606.4 L798.5,588.7 L788.0,577.8 L788.0,595.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="464.7,607.1 464.7,282.1 534.5,274.4 534.5,599.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M464.7,607.1 L534.5,599.4 L534.5,274.4 L464.7,282.1 L464.7,607.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="464.7,607.1 464.7,282.1 534.5,274.4 534.5,599.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M464.7,607.1 L534.5,599.4 L534.5,274.4 L464.7,282.1 L464.7,607.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="464.7,607.1 464.7,282.1 534.5,274.4 534.5,599.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M464.7,607.1 L534.5,599.4 L534.5,274.4 L464.7,282.1 L464.7,607.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="971.7,599.3 971.7,577.2 982.1,588.1 982.1,610.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M971.7,599.3 L982.1,610.2 L982.1,588.1 L971.7,577.2 L971.7,599.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="971.7,599.3 971.7,577.2 982.1,588.1 982.1,610.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M971.7,599.3 L982.1,610.2 L982.1,588.1 L971.7,577.2 L971.7,599.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="971.7,599.3 971.7,577.2 982.1,588.1 982.1,610.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M971.7,599.3 L982.1,610.2 L982.1,588.1 L971.7,577.2 L971.7,599.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="718.2,585.5 788.0,577.8 798.5,588.7 728.6,596.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M718.2,585.5 L728.6,596.4 L798.5,588.7 L788.0,577.8 L718.2,585.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="718.2,585.5 788.0,577.8 798.5,588.7 728.6,596.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M718.2,585.5 L728.6,596.4 L798.5,588.7 L788.0,577.8 L718.2,585.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="718.2,585.5 788.0,577.8 798.5,588.7 728.6,596.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M718.2,585.5 L728.6,596.4 L798.5,588.7 L788.0,577.8 L718.2,585.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="534.5,599.4 534.5,274.4 544.9,285.3 544.9,610.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M534.5,599.4 L544.9,610.3 L544.9,285.3 L534.5,274.4 L534.5,599.4  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="534.5,599.4 534.5,274.4 544.9,285.3 544.9,610.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M534.5,599.4 L544.9,610.3 L544.9,285.3 L534.5,274.4 L534.5,599.4  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="534.5,599.4 534.5,274.4 544.9,285.3 544.9,610.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M534.5,599.4 L544.9,610.3 L544.9,285.3 L534.5,274.4 L534.5,599.4  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="982.1,610.2 982.1,588.1 1051.9,580.4 1051.9,602.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M982.1,610.2 L1051.9,602.5 L1051.9,580.4 L982.1,588.1 L982.1,610.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="982.1,610.2 982.1,588.1 1051.9,580.4 1051.9,602.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M982.1,610.2 L1051.9,602.5 L1051.9,580.4 L982.1,588.1 L982.1,610.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="982.1,610.2 982.1,588.1 1051.9,580.4 1051.9,602.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M982.1,610.2 L1051.9,602.5 L1051.9,580.4 L982.1,588.1 L982.1,610.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="718.2,603.2 718.2,585.5 728.6,596.4 728.6,614.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M718.2,603.2 L728.6,614.1 L728.6,596.4 L718.2,585.5 L718.2,603.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="718.2,603.2 718.2,585.5 728.6,596.4 728.6,614.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M718.2,603.2 L728.6,614.1 L728.6,596.4 L718.2,585.5 L718.2,603.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="718.2,603.2 718.2,585.5 728.6,596.4 728.6,614.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M718.2,603.2 L728.6,614.1 L728.6,596.4 L718.2,585.5 L718.2,603.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="464.7,282.1 534.5,274.4 544.9,285.3 475.1,293.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M464.7,282.1 L475.1,293.0 L544.9,285.3 L534.5,274.4 L464.7,282.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="464.7,282.1 534.5,274.4 544.9,285.3 475.1,293.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M464.7,282.1 L475.1,293.0 L544.9,285.3 L534.5,274.4 L464.7,282.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="464.7,282.1 534.5,274.4 544.9,285.3 475.1,293.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M464.7,282.1 L475.1,293.0 L544.9,285.3 L534.5,274.4 L464.7,282.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="728.6,614.1 728.6,596.4 798.5,588.7 798.5,606.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M728.6,614.1 L798.5,606.4 L798.5,588.7 L728.6,596.4 L728.6,614.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="728.6,614.1 728.6,596.4 798.5,588.7 798.5,606.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M728.6,614.1 L798.5,606.4 L798.5,588.7 L728.6,596.4 L728.6,614.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="728.6,614.1 728.6,596.4 798.5,588.7 798.5,606.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M728.6,614.1 L798.5,606.4 L798.5,588.7 L728.6,596.4 L728.6,614.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="464.7,607.1 464.7,282.1 475.1,293.0 475.1,618.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M464.7,607.1 L475.1,618.0 L475.1,293.0 L464.7,282.1 L464.7,607.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="464.7,607.1 464.7,282.1 475.1,293.0 475.1,618.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M464.7,607.1 L475.1,618.0 L475.1,293.0 L464.7,282.1 L464.7,607.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="464.7,607.1 464.7,282.1 475.1,293.0 475.1,618.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M464.7,607.1 L475.1,618.0 L475.1,293.0 L464.7,282.1 L464.7,607.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="475.1,618.0 475.1,293.0 544.9,285.3 544.9,610.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M475.1,618.0 L544.9,610.3 L544.9,285.3 L475.1,293.0 L475.1,618.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="475.1,618.0 475.1,293.0 544.9,285.3 544.9,610.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M475.1,618.0 L544.9,610.3 L544.9,285.3 L475.1,293.0 L475.1,618.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="475.1,618.0 475.1,293.0 544.9,285.3 544.9,610.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M475.1,618.0 L544.9,610.3 L544.9,285.3 L475.1,293.0 L475.1,618.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="992.5,621.2 992.5,583.5 1062.3,575.8 1062.3,613.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M992.5,621.2 L1062.3,613.5 L1062.3,575.8 L992.5,583.5 L992.5,621.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="992.5,621.2 992.5,583.5 1062.3,575.8 1062.3,613.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M992.5,621.2 L1062.3,613.5 L1062.3,575.8 L992.5,583.5 L992.5,621.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="992.5,621.2 992.5,583.5 1062.3,575.8 1062.3,613.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M992.5,621.2 L1062.3,613.5 L1062.3,575.8 L992.5,583.5 L992.5,621.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1062.3,613.5 1062.3,575.8 1072.8,586.7 1072.8,624.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1062.3,613.5 L1072.8,624.4 L1072.8,586.7 L1062.3,575.8 L1062.3,613.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1062.3,613.5 1062.3,575.8 1072.8,586.7 1072.8,624.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1062.3,613.5 L1072.8,624.4 L1072.8,586.7 L1062.3,575.8 L1062.3,613.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1062.3,613.5 1062.3,575.8 1072.8,586.7 1072.8,624.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1062.3,613.5 L1072.8,624.4 L1072.8,586.7 L1062.3,575.8 L1062.3,613.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="739.1,625.1 739.1,602.9 808.8,595.2 808.8,617.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M739.1,625.1 L808.8,617.3 L808.8,595.2 L739.1,602.9 L739.1,625.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="739.1,625.1 739.1,602.9 808.8,595.2 808.8,617.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M739.1,625.1 L808.8,617.3 L808.8,595.2 L739.1,602.9 L739.1,625.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="739.1,625.1 739.1,602.9 808.8,595.2 808.8,617.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M739.1,625.1 L808.8,617.3 L808.8,595.2 L739.1,602.9 L739.1,625.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="992.5,583.5 1062.3,575.8 1072.8,586.7 1003.0,594.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M992.5,583.5 L1003.0,594.4 L1072.8,586.7 L1062.3,575.8 L992.5,583.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="992.5,583.5 1062.3,575.8 1072.8,586.7 1003.0,594.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M992.5,583.5 L1003.0,594.4 L1072.8,586.7 L1062.3,575.8 L992.5,583.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="992.5,583.5 1062.3,575.8 1072.8,586.7 1003.0,594.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M992.5,583.5 L1003.0,594.4 L1072.8,586.7 L1062.3,575.8 L992.5,583.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="808.8,617.3 808.8,595.2 819.2,606.1 819.2,628.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M808.8,617.3 L819.2,628.3 L819.2,606.1 L808.8,595.2 L808.8,617.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="808.8,617.3 808.8,595.2 819.2,606.1 819.2,628.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M808.8,617.3 L819.2,628.3 L819.2,606.1 L808.8,595.2 L808.8,617.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="808.8,617.3 808.8,595.2 819.2,606.1 819.2,628.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M808.8,617.3 L819.2,628.3 L819.2,606.1 L808.8,595.2 L808.8,617.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="485.5,628.9 485.5,580.3 555.3,572.5 555.3,621.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M485.5,628.9 L555.3,621.2 L555.3,572.5 L485.5,580.3 L485.5,628.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="485.5,628.9 485.5,580.3 555.3,572.5 555.3,621.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M485.5,628.9 L555.3,621.2 L555.3,572.5 L485.5,580.3 L485.5,628.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="485.5,628.9 485.5,580.3 555.3,572.5 555.3,621.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M485.5,628.9 L555.3,621.2 L555.3,572.5 L485.5,580.3 L485.5,628.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="992.5,621.2 992.5,583.5 1003.0,594.4 1003.0,632.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M992.5,621.2 L1003.0,632.1 L1003.0,594.4 L992.5,583.5 L992.5,621.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="992.5,621.2 992.5,583.5 1003.0,594.4 1003.0,632.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M992.5,621.2 L1003.0,632.1 L1003.0,594.4 L992.5,583.5 L992.5,621.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="992.5,621.2 992.5,583.5 1003.0,594.4 1003.0,632.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M992.5,621.2 L1003.0,632.1 L1003.0,594.4 L992.5,583.5 L992.5,621.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="739.1,602.9 808.8,595.2 819.2,606.1 749.5,613.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M739.1,602.9 L749.5,613.9 L819.2,606.1 L808.8,595.2 L739.1,602.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="739.1,602.9 808.8,595.2 819.2,606.1 749.5,613.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M739.1,602.9 L749.5,613.9 L819.2,606.1 L808.8,595.2 L739.1,602.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="739.1,602.9 808.8,595.2 819.2,606.1 749.5,613.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M739.1,602.9 L749.5,613.9 L819.2,606.1 L808.8,595.2 L739.1,602.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="555.3,621.2 555.3,572.5 565.8,583.5 565.8,632.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M555.3,621.2 L565.8,632.2 L565.8,583.5 L555.3,572.5 L555.3,621.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="555.3,621.2 555.3,572.5 565.8,583.5 565.8,632.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M555.3,621.2 L565.8,632.2 L565.8,583.5 L555.3,572.5 L555.3,621.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="555.3,621.2 555.3,572.5 565.8,583.5 565.8,632.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M555.3,621.2 L565.8,632.2 L565.8,583.5 L555.3,572.5 L555.3,621.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1003.0,632.1 1003.0,594.4 1072.8,586.7 1072.8,624.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1003.0,632.1 L1072.8,624.4 L1072.8,586.7 L1003.0,594.4 L1003.0,632.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1003.0,632.1 1003.0,594.4 1072.8,586.7 1072.8,624.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1003.0,632.1 L1072.8,624.4 L1072.8,586.7 L1003.0,594.4 L1003.0,632.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1003.0,632.1 1003.0,594.4 1072.8,586.7 1072.8,624.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1003.0,632.1 L1072.8,624.4 L1072.8,586.7 L1003.0,594.4 L1003.0,632.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="739.1,625.1 739.1,602.9 749.5,613.9 749.5,636.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M739.1,625.1 L749.5,636.0 L749.5,613.9 L739.1,602.9 L739.1,625.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="739.1,625.1 739.1,602.9 749.5,613.9 749.5,636.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M739.1,625.1 L749.5,636.0 L749.5,613.9 L739.1,602.9 L739.1,625.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="739.1,625.1 739.1,602.9 749.5,613.9 749.5,636.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M739.1,625.1 L749.5,636.0 L749.5,613.9 L739.1,602.9 L739.1,625.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="485.5,580.3 555.3,572.5 565.8,583.5 496.0,591.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M485.5,580.3 L496.0,591.2 L565.8,583.5 L555.3,572.5 L485.5,580.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="485.5,580.3 555.3,572.5 565.8,583.5 496.0,591.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M485.5,580.3 L496.0,591.2 L565.8,583.5 L555.3,572.5 L485.5,580.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="485.5,580.3 555.3,572.5 565.8,583.5 496.0,591.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M485.5,580.3 L496.0,591.2 L565.8,583.5 L555.3,572.5 L485.5,580.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="749.5,636.0 749.5,613.9 819.2,606.1 819.2,628.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M749.5,636.0 L819.2,628.3 L819.2,606.1 L749.5,613.9 L749.5,636.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="749.5,636.0 749.5,613.9 819.2,606.1 819.2,628.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M749.5,636.0 L819.2,628.3 L819.2,606.1 L749.5,613.9 L749.5,636.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="749.5,636.0 749.5,613.9 819.2,606.1 819.2,628.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M749.5,636.0 L819.2,628.3 L819.2,606.1 L749.5,613.9 L749.5,636.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="485.5,628.9 485.5,580.3 496.0,591.2 496.0,639.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M485.5,628.9 L496.0,639.9 L496.0,591.2 L485.5,580.3 L485.5,628.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="485.5,628.9 485.5,580.3 496.0,591.2 496.0,639.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M485.5,628.9 L496.0,639.9 L496.0,591.2 L485.5,580.3 L485.5,628.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="485.5,628.9 485.5,580.3 496.0,591.2 496.0,639.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M485.5,628.9 L496.0,639.9 L496.0,591.2 L485.5,580.3 L485.5,628.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="496.0,639.9 496.0,591.2 565.8,583.5 565.8,632.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M496.0,639.9 L565.8,632.2 L565.8,583.5 L496.0,591.2 L496.0,639.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="496.0,639.9 496.0,591.2 565.8,583.5 565.8,632.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M496.0,639.9 L565.8,632.2 L565.8,583.5 L496.0,591.2 L496.0,639.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="496.0,639.9 496.0,591.2 565.8,583.5 565.8,632.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M496.0,639.9 L565.8,632.2 L565.8,583.5 L496.0,591.2 L496.0,639.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1013.4,643.0 1013.4,636.3 1083.2,628.5 1083.2,635.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1013.4,643.0 L1083.2,635.3 L1083.2,628.5 L1013.4,636.3 L1013.4,643.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1013.4,643.0 1013.4,636.3 1083.2,628.5 1083.2,635.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1013.4,643.0 L1083.2,635.3 L1083.2,628.5 L1013.4,636.3 L1013.4,643.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1013.4,643.0 1013.4,636.3 1083.2,628.5 1083.2,635.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1013.4,643.0 L1083.2,635.3 L1083.2,628.5 L1013.4,636.3 L1013.4,643.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1083.2,635.3 1083.2,628.5 1093.6,639.5 1093.6,646.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1083.2,635.3 L1093.6,646.2 L1093.6,639.5 L1083.2,628.5 L1083.2,635.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1083.2,635.3 1083.2,628.5 1093.6,639.5 1093.6,646.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1083.2,635.3 L1093.6,646.2 L1093.6,639.5 L1083.2,628.5 L1083.2,635.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1083.2,635.3 1083.2,628.5 1093.6,639.5 1093.6,646.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1083.2,635.3 L1093.6,646.2 L1093.6,639.5 L1083.2,628.5 L1083.2,635.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="759.9,646.9 759.9,609.2 829.6,601.5 829.6,639.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M759.9,646.9 L829.6,639.2 L829.6,601.5 L759.9,609.2 L759.9,646.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="759.9,646.9 759.9,609.2 829.6,601.5 829.6,639.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M759.9,646.9 L829.6,639.2 L829.6,601.5 L759.9,609.2 L759.9,646.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="759.9,646.9 759.9,609.2 829.6,601.5 829.6,639.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M759.9,646.9 L829.6,639.2 L829.6,601.5 L759.9,609.2 L759.9,646.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1013.4,636.3 1083.2,628.5 1093.6,639.5 1023.8,647.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1013.4,636.3 L1023.8,647.2 L1093.6,639.5 L1083.2,628.5 L1013.4,636.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1013.4,636.3 1083.2,628.5 1093.6,639.5 1023.8,647.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1013.4,636.3 L1023.8,647.2 L1093.6,639.5 L1083.2,628.5 L1013.4,636.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1013.4,636.3 1083.2,628.5 1093.6,639.5 1023.8,647.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1013.4,636.3 L1023.8,647.2 L1093.6,639.5 L1083.2,628.5 L1013.4,636.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="829.6,639.2 829.6,601.5 840.1,612.5 840.1,650.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M829.6,639.2 L840.1,650.1 L840.1,612.5 L829.6,601.5 L829.6,639.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="829.6,639.2 829.6,601.5 840.1,612.5 840.1,650.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M829.6,639.2 L840.1,650.1 L840.1,612.5 L829.6,601.5 L829.6,639.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="829.6,639.2 829.6,601.5 840.1,612.5 840.1,650.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M829.6,639.2 L840.1,650.1 L840.1,612.5 L829.6,601.5 L829.6,639.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="506.4,650.8 506.4,604.3 576.2,596.6 576.2,643.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M506.4,650.8 L576.2,643.1 L576.2,596.6 L506.4,604.3 L506.4,650.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="506.4,650.8 506.4,604.3 576.2,596.6 576.2,643.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M506.4,650.8 L576.2,643.1 L576.2,596.6 L506.4,604.3 L506.4,650.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="506.4,650.8 506.4,604.3 576.2,596.6 576.2,643.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M506.4,650.8 L576.2,643.1 L576.2,596.6 L506.4,604.3 L506.4,650.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1013.4,643.0 1013.4,636.3 1023.8,647.2 1023.8,654.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1013.4,643.0 L1023.8,654.0 L1023.8,647.2 L1013.4,636.3 L1013.4,643.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1013.4,643.0 1013.4,636.3 1023.8,647.2 1023.8,654.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1013.4,643.0 L1023.8,654.0 L1023.8,647.2 L1013.4,636.3 L1013.4,643.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1013.4,643.0 1013.4,636.3 1023.8,647.2 1023.8,654.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1013.4,643.0 L1023.8,654.0 L1023.8,647.2 L1013.4,636.3 L1013.4,643.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="759.9,609.2 829.6,601.5 840.1,612.5 770.4,620.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M759.9,609.2 L770.4,620.2 L840.1,612.5 L829.6,601.5 L759.9,609.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="759.9,609.2 829.6,601.5 840.1,612.5 770.4,620.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M759.9,609.2 L770.4,620.2 L840.1,612.5 L829.6,601.5 L759.9,609.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="759.9,609.2 829.6,601.5 840.1,612.5 770.4,620.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M759.9,609.2 L770.4,620.2 L840.1,612.5 L829.6,601.5 L759.9,609.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="576.2,643.1 576.2,596.6 586.6,607.5 586.6,654.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M576.2,643.1 L586.6,654.0 L586.6,607.5 L576.2,596.6 L576.2,643.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="576.2,643.1 576.2,596.6 586.6,607.5 586.6,654.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M576.2,643.1 L586.6,654.0 L586.6,607.5 L576.2,596.6 L576.2,643.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="576.2,643.1 576.2,596.6 586.6,607.5 586.6,654.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M576.2,643.1 L586.6,654.0 L586.6,607.5 L576.2,596.6 L576.2,643.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1023.8,654.0 1023.8,647.2 1093.6,639.5 1093.6,646.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1023.8,654.0 L1093.6,646.2 L1093.6,639.5 L1023.8,647.2 L1023.8,654.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1023.8,654.0 1023.8,647.2 1093.6,639.5 1093.6,646.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1023.8,654.0 L1093.6,646.2 L1093.6,639.5 L1023.8,647.2 L1023.8,654.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1023.8,654.0 1023.8,647.2 1093.6,639.5 1093.6,646.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1023.8,654.0 L1093.6,646.2 L1093.6,639.5 L1023.8,647.2 L1023.8,654.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="759.9,646.9 759.9,609.2 770.4,620.2 770.4,657.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M759.9,646.9 L770.4,657.8 L770.4,620.2 L759.9,609.2 L759.9,646.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="759.9,646.9 759.9,609.2 770.4,620.2 770.4,657.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M759.9,646.9 L770.4,657.8 L770.4,620.2 L759.9,609.2 L759.9,646.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="759.9,646.9 759.9,609.2 770.4,620.2 770.4,657.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M759.9,646.9 L770.4,657.8 L770.4,620.2 L759.9,609.2 L759.9,646.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="506.4,604.3 576.2,596.6 586.6,607.5 516.8,615.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M506.4,604.3 L516.8,615.2 L586.6,607.5 L576.2,596.6 L506.4,604.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="506.4,604.3 576.2,596.6 586.6,607.5 516.8,615.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M506.4,604.3 L516.8,615.2 L586.6,607.5 L576.2,596.6 L506.4,604.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="506.4,604.3 576.2,596.6 586.6,607.5 516.8,615.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M506.4,604.3 L516.8,615.2 L586.6,607.5 L576.2,596.6 L506.4,604.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="770.4,657.8 770.4,620.2 840.1,612.5 840.1,650.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M770.4,657.8 L840.1,650.1 L840.1,612.5 L770.4,620.2 L770.4,657.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="770.4,657.8 770.4,620.2 840.1,612.5 840.1,650.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M770.4,657.8 L840.1,650.1 L840.1,612.5 L770.4,620.2 L770.4,657.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="770.4,657.8 770.4,620.2 840.1,612.5 840.1,650.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M770.4,657.8 L840.1,650.1 L840.1,612.5 L770.4,620.2 L770.4,657.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="506.4,650.8 506.4,604.3 516.8,615.2 516.8,661.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M506.4,650.8 L516.8,661.7 L516.8,615.2 L506.4,604.3 L506.4,650.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="506.4,650.8 506.4,604.3 516.8,615.2 516.8,661.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M506.4,650.8 L516.8,661.7 L516.8,615.2 L506.4,604.3 L506.4,650.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="506.4,650.8 506.4,604.3 516.8,615.2 516.8,661.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M506.4,650.8 L516.8,661.7 L516.8,615.2 L506.4,604.3 L506.4,650.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="516.8,661.7 516.8,615.2 586.6,607.5 586.6,654.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M516.8,661.7 L586.6,654.0 L586.6,607.5 L516.8,615.2 L516.8,661.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="516.8,661.7 516.8,615.2 586.6,607.5 586.6,654.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M516.8,661.7 L586.6,654.0 L586.6,607.5 L516.8,615.2 L516.8,661.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="516.8,661.7 516.8,615.2 586.6,607.5 586.6,654.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M516.8,661.7 L586.6,654.0 L586.6,607.5 L516.8,615.2 L516.8,661.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1034.2,664.9 1034.2,653.8 1104.0,646.1 1104.0,657.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1034.2,664.9 L1104.0,657.2 L1104.0,646.1 L1034.2,653.8 L1034.2,664.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1034.2,664.9 1034.2,653.8 1104.0,646.1 1104.0,657.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1034.2,664.9 L1104.0,657.2 L1104.0,646.1 L1034.2,653.8 L1034.2,664.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1034.2,664.9 1034.2,653.8 1104.0,646.1 1104.0,657.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1034.2,664.9 L1104.0,657.2 L1104.0,646.1 L1034.2,653.8 L1034.2,664.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1104.0,657.2 1104.0,646.1 1114.5,657.0 1114.5,668.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1104.0,657.2 L1114.5,668.1 L1114.5,657.0 L1104.0,646.1 L1104.0,657.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1104.0,657.2 1104.0,646.1 1114.5,657.0 1114.5,668.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1104.0,657.2 L1114.5,668.1 L1114.5,657.0 L1104.0,646.1 L1104.0,657.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1104.0,657.2 1104.0,646.1 1114.5,657.0 1114.5,668.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1104.0,657.2 L1114.5,668.1 L1114.5,657.0 L1104.0,646.1 L1104.0,657.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="780.8,668.8 780.8,662.0 850.5,654.3 850.5,661.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M780.8,668.8 L850.5,661.1 L850.5,654.3 L780.8,662.0 L780.8,668.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="780.8,668.8 780.8,662.0 850.5,654.3 850.5,661.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M780.8,668.8 L850.5,661.1 L850.5,654.3 L780.8,662.0 L780.8,668.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="780.8,668.8 780.8,662.0 850.5,654.3 850.5,661.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M780.8,668.8 L850.5,661.1 L850.5,654.3 L780.8,662.0 L780.8,668.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1034.2,653.8 1104.0,646.1 1114.5,657.0 1044.7,664.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1034.2,653.8 L1044.7,664.8 L1114.5,657.0 L1104.0,646.1 L1034.2,653.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1034.2,653.8 1104.0,646.1 1114.5,657.0 1044.7,664.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1034.2,653.8 L1044.7,664.8 L1114.5,657.0 L1104.0,646.1 L1034.2,653.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1034.2,653.8 1104.0,646.1 1114.5,657.0 1044.7,664.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1034.2,653.8 L1044.7,664.8 L1114.5,657.0 L1104.0,646.1 L1034.2,653.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="850.5,661.1 850.5,654.3 860.9,665.2 860.9,672.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M850.5,661.1 L860.9,672.0 L860.9,665.2 L850.5,654.3 L850.5,661.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="850.5,661.1 850.5,654.3 860.9,665.2 860.9,672.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M850.5,661.1 L860.9,672.0 L860.9,665.2 L850.5,654.3 L850.5,661.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="850.5,661.1 850.5,654.3 860.9,665.2 860.9,672.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M850.5,661.1 L860.9,672.0 L860.9,665.2 L850.5,654.3 L850.5,661.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="527.2,672.7 527.2,628.5 597.0,620.7 597.0,664.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M527.2,672.7 L597.0,664.9 L597.0,620.7 L527.2,628.5 L527.2,672.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="527.2,672.7 527.2,628.5 597.0,620.7 597.0,664.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M527.2,672.7 L597.0,664.9 L597.0,620.7 L527.2,628.5 L527.2,672.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="527.2,672.7 527.2,628.5 597.0,620.7 597.0,664.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M527.2,672.7 L597.0,664.9 L597.0,620.7 L527.2,628.5 L527.2,672.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1034.2,664.9 1034.2,653.8 1044.7,664.8 1044.7,675.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1034.2,664.9 L1044.7,675.8 L1044.7,664.8 L1034.2,653.8 L1034.2,664.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1034.2,664.9 1034.2,653.8 1044.7,664.8 1044.7,675.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1034.2,664.9 L1044.7,675.8 L1044.7,664.8 L1034.2,653.8 L1034.2,664.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1034.2,664.9 1034.2,653.8 1044.7,664.8 1044.7,675.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1034.2,664.9 L1044.7,675.8 L1044.7,664.8 L1034.2,653.8 L1034.2,664.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="780.8,662.0 850.5,654.3 860.9,665.2 791.2,672.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M780.8,662.0 L791.2,672.9 L860.9,665.2 L850.5,654.3 L780.8,662.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="780.8,662.0 850.5,654.3 860.9,665.2 791.2,672.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M780.8,662.0 L791.2,672.9 L860.9,665.2 L850.5,654.3 L780.8,662.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="780.8,662.0 850.5,654.3 860.9,665.2 791.2,672.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M780.8,662.0 L791.2,672.9 L860.9,665.2 L850.5,654.3 L780.8,662.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="597.0,664.9 597.0,620.7 607.5,631.7 607.5,675.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M597.0,664.9 L607.5,675.9 L607.5,631.7 L597.0,620.7 L597.0,664.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="597.0,664.9 597.0,620.7 607.5,631.7 607.5,675.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M597.0,664.9 L607.5,675.9 L607.5,631.7 L597.0,620.7 L597.0,664.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="597.0,664.9 597.0,620.7 607.5,631.7 607.5,675.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M597.0,664.9 L607.5,675.9 L607.5,631.7 L597.0,620.7 L597.0,664.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1044.7,675.8 1044.7,664.8 1114.5,657.0 1114.5,668.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1044.7,675.8 L1114.5,668.1 L1114.5,657.0 L1044.7,664.8 L1044.7,675.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1044.7,675.8 1044.7,664.8 1114.5,657.0 1114.5,668.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1044.7,675.8 L1114.5,668.1 L1114.5,657.0 L1044.7,664.8 L1044.7,675.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1044.7,675.8 1044.7,664.8 1114.5,657.0 1114.5,668.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1044.7,675.8 L1114.5,668.1 L1114.5,657.0 L1044.7,664.8 L1044.7,675.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="780.8,668.8 780.8,662.0 791.2,672.9 791.2,679.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M780.8,668.8 L791.2,679.7 L791.2,672.9 L780.8,662.0 L780.8,668.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="780.8,668.8 780.8,662.0 791.2,672.9 791.2,679.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M780.8,668.8 L791.2,679.7 L791.2,672.9 L780.8,662.0 L780.8,668.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="780.8,668.8 780.8,662.0 791.2,672.9 791.2,679.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M780.8,668.8 L791.2,679.7 L791.2,672.9 L780.8,662.0 L780.8,668.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="527.2,628.5 597.0,620.7 607.5,631.7 537.7,639.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M527.2,628.5 L537.7,639.4 L607.5,631.7 L597.0,620.7 L527.2,628.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="527.2,628.5 597.0,620.7 607.5,631.7 537.7,639.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M527.2,628.5 L537.7,639.4 L607.5,631.7 L597.0,620.7 L527.2,628.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="527.2,628.5 597.0,620.7 607.5,631.7 537.7,639.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M527.2,628.5 L537.7,639.4 L607.5,631.7 L597.0,620.7 L527.2,628.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="791.2,679.7 791.2,672.9 860.9,665.2 860.9,672.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M791.2,679.7 L860.9,672.0 L860.9,665.2 L791.2,672.9 L791.2,679.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="791.2,679.7 791.2,672.9 860.9,665.2 860.9,672.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M791.2,679.7 L860.9,672.0 L860.9,665.2 L791.2,672.9 L791.2,679.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="791.2,679.7 791.2,672.9 860.9,665.2 860.9,672.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M791.2,679.7 L860.9,672.0 L860.9,665.2 L791.2,672.9 L791.2,679.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="527.2,672.7 527.2,628.5 537.7,639.4 537.7,683.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M527.2,672.7 L537.7,683.6 L537.7,639.4 L527.2,628.5 L527.2,672.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="527.2,672.7 527.2,628.5 537.7,639.4 537.7,683.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M527.2,672.7 L537.7,683.6 L537.7,639.4 L527.2,628.5 L527.2,672.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="527.2,672.7 527.2,628.5 537.7,639.4 537.7,683.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M527.2,672.7 L537.7,683.6 L537.7,639.4 L527.2,628.5 L527.2,672.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="537.7,683.6 537.7,639.4 607.5,631.7 607.5,675.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M537.7,683.6 L607.5,675.9 L607.5,631.7 L537.7,639.4 L537.7,683.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="537.7,683.6 537.7,639.4 607.5,631.7 607.5,675.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M537.7,683.6 L607.5,675.9 L607.5,631.7 L537.7,639.4 L537.7,683.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="537.7,683.6 537.7,639.4 607.5,631.7 607.5,675.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M537.7,683.6 L607.5,675.9 L607.5,631.7 L537.7,639.4 L537.7,683.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1055.1,686.7 1055.1,673.3 1124.9,665.6 1124.9,679.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1055.1,686.7 L1124.9,679.0 L1124.9,665.6 L1055.1,673.3 L1055.1,686.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1055.1,686.7 1055.1,673.3 1124.9,665.6 1124.9,679.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1055.1,686.7 L1124.9,679.0 L1124.9,665.6 L1055.1,673.3 L1055.1,686.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1055.1,686.7 1055.1,673.3 1124.9,665.6 1124.9,679.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1055.1,686.7 L1124.9,679.0 L1124.9,665.6 L1055.1,673.3 L1055.1,686.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1124.9,679.0 1124.9,665.6 1135.3,676.6 1135.3,690.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1124.9,679.0 L1135.3,690.0 L1135.3,676.6 L1124.9,665.6 L1124.9,679.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1124.9,679.0 1124.9,665.6 1135.3,676.6 1135.3,690.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1124.9,679.0 L1135.3,690.0 L1135.3,676.6 L1124.9,665.6 L1124.9,679.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1124.9,679.0 1124.9,665.6 1135.3,676.6 1135.3,690.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1124.9,679.0 L1135.3,690.0 L1135.3,676.6 L1124.9,665.6 L1124.9,679.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="801.5,690.6 801.5,679.6 871.4,671.8 871.4,682.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M801.5,690.6 L871.4,682.9 L871.4,671.8 L801.5,679.6 L801.5,690.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="801.5,690.6 801.5,679.6 871.4,671.8 871.4,682.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M801.5,690.6 L871.4,682.9 L871.4,671.8 L801.5,679.6 L801.5,690.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="801.5,690.6 801.5,679.6 871.4,671.8 871.4,682.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M801.5,690.6 L871.4,682.9 L871.4,671.8 L801.5,679.6 L801.5,690.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1055.1,673.3 1124.9,665.6 1135.3,676.6 1065.5,684.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1055.1,673.3 L1065.5,684.3 L1135.3,676.6 L1124.9,665.6 L1055.1,673.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1055.1,673.3 1124.9,665.6 1135.3,676.6 1065.5,684.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1055.1,673.3 L1065.5,684.3 L1135.3,676.6 L1124.9,665.6 L1055.1,673.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1055.1,673.3 1124.9,665.6 1135.3,676.6 1065.5,684.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1055.1,673.3 L1065.5,684.3 L1135.3,676.6 L1124.9,665.6 L1055.1,673.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="871.4,682.9 871.4,671.8 881.8,682.8 881.8,693.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M871.4,682.9 L881.8,693.8 L881.8,682.8 L871.4,671.8 L871.4,682.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="871.4,682.9 871.4,671.8 881.8,682.8 881.8,693.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M871.4,682.9 L881.8,693.8 L881.8,682.8 L871.4,671.8 L871.4,682.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="871.4,682.9 871.4,671.8 881.8,682.8 881.8,693.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M871.4,682.9 L881.8,693.8 L881.8,682.8 L871.4,671.8 L871.4,682.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="548.1,694.5 548.1,690.1 617.9,682.4 617.9,686.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M548.1,694.5 L617.9,686.8 L617.9,682.4 L548.1,690.1 L548.1,694.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="548.1,694.5 548.1,690.1 617.9,682.4 617.9,686.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M548.1,694.5 L617.9,686.8 L617.9,682.4 L548.1,690.1 L548.1,694.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="548.1,694.5 548.1,690.1 617.9,682.4 617.9,686.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M548.1,694.5 L617.9,686.8 L617.9,682.4 L548.1,690.1 L548.1,694.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1055.1,686.7 1055.1,673.3 1065.5,684.3 1065.5,697.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1055.1,686.7 L1065.5,697.7 L1065.5,684.3 L1055.1,673.3 L1055.1,686.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1055.1,686.7 1055.1,673.3 1065.5,684.3 1065.5,697.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1055.1,686.7 L1065.5,697.7 L1065.5,684.3 L1055.1,673.3 L1055.1,686.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1055.1,686.7 1055.1,673.3 1065.5,684.3 1065.5,697.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1055.1,686.7 L1065.5,697.7 L1065.5,684.3 L1055.1,673.3 L1055.1,686.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="801.5,679.6 871.4,671.8 881.8,682.8 812.0,690.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M801.5,679.6 L812.0,690.5 L881.8,682.8 L871.4,671.8 L801.5,679.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="801.5,679.6 871.4,671.8 881.8,682.8 812.0,690.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M801.5,679.6 L812.0,690.5 L881.8,682.8 L871.4,671.8 L801.5,679.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="801.5,679.6 871.4,671.8 881.8,682.8 812.0,690.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M801.5,679.6 L812.0,690.5 L881.8,682.8 L871.4,671.8 L801.5,679.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="617.9,686.8 617.9,682.4 628.3,693.3 628.3,697.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M617.9,686.8 L628.3,697.7 L628.3,693.3 L617.9,682.4 L617.9,686.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="617.9,686.8 617.9,682.4 628.3,693.3 628.3,697.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M617.9,686.8 L628.3,697.7 L628.3,693.3 L617.9,682.4 L617.9,686.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="617.9,686.8 617.9,682.4 628.3,693.3 628.3,697.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M617.9,686.8 L628.3,697.7 L628.3,693.3 L617.9,682.4 L617.9,686.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1065.5,697.7 1065.5,684.3 1135.3,676.6 1135.3,690.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1065.5,697.7 L1135.3,690.0 L1135.3,676.6 L1065.5,684.3 L1065.5,697.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1065.5,697.7 1065.5,684.3 1135.3,676.6 1135.3,690.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1065.5,697.7 L1135.3,690.0 L1135.3,676.6 L1065.5,684.3 L1065.5,697.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1065.5,697.7 1065.5,684.3 1135.3,676.6 1135.3,690.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1065.5,697.7 L1135.3,690.0 L1135.3,676.6 L1065.5,684.3 L1065.5,697.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="801.5,690.6 801.5,679.6 812.0,690.5 812.0,701.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M801.5,690.6 L812.0,701.6 L812.0,690.5 L801.5,679.6 L801.5,690.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="801.5,690.6 801.5,679.6 812.0,690.5 812.0,701.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M801.5,690.6 L812.0,701.6 L812.0,690.5 L801.5,679.6 L801.5,690.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="801.5,690.6 801.5,679.6 812.0,690.5 812.0,701.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M801.5,690.6 L812.0,701.6 L812.0,690.5 L801.5,679.6 L801.5,690.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="548.1,690.1 617.9,682.4 628.3,693.3 558.5,701.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M548.1,690.1 L558.5,701.0 L628.3,693.3 L617.9,682.4 L548.1,690.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="548.1,690.1 617.9,682.4 628.3,693.3 558.5,701.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M548.1,690.1 L558.5,701.0 L628.3,693.3 L617.9,682.4 L548.1,690.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="548.1,690.1 617.9,682.4 628.3,693.3 558.5,701.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M548.1,690.1 L558.5,701.0 L628.3,693.3 L617.9,682.4 L548.1,690.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="812.0,701.6 812.0,690.5 881.8,682.8 881.8,693.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M812.0,701.6 L881.8,693.8 L881.8,682.8 L812.0,690.5 L812.0,701.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="812.0,701.6 812.0,690.5 881.8,682.8 881.8,693.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M812.0,701.6 L881.8,693.8 L881.8,682.8 L812.0,690.5 L812.0,701.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="812.0,701.6 812.0,690.5 881.8,682.8 881.8,693.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M812.0,701.6 L881.8,693.8 L881.8,682.8 L812.0,690.5 L812.0,701.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="548.1,694.5 548.1,690.1 558.5,701.0 558.5,705.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M548.1,694.5 L558.5,705.4 L558.5,701.0 L548.1,690.1 L548.1,694.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="548.1,694.5 548.1,690.1 558.5,701.0 558.5,705.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M548.1,694.5 L558.5,705.4 L558.5,701.0 L548.1,690.1 L548.1,694.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="548.1,694.5 548.1,690.1 558.5,701.0 558.5,705.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M548.1,694.5 L558.5,705.4 L558.5,701.0 L548.1,690.1 L548.1,694.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="558.5,705.4 558.5,701.0 628.3,693.3 628.3,697.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M558.5,705.4 L628.3,697.7 L628.3,693.3 L558.5,701.0 L558.5,705.4  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="558.5,705.4 558.5,701.0 628.3,693.3 628.3,697.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M558.5,705.4 L628.3,697.7 L628.3,693.3 L558.5,701.0 L558.5,705.4  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="558.5,705.4 558.5,701.0 628.3,693.3 628.3,697.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M558.5,705.4 L628.3,697.7 L628.3,693.3 L558.5,701.0 L558.5,705.4  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1076.0,708.6 1076.0,704.1 1145.8,696.4 1145.8,700.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1076.0,708.6 L1145.8,700.9 L1145.8,696.4 L1076.0,704.1 L1076.0,708.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1076.0,708.6 1076.0,704.1 1145.8,696.4 1145.8,700.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1076.0,708.6 L1145.8,700.9 L1145.8,696.4 L1076.0,704.1 L1076.0,708.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1076.0,708.6 1076.0,704.1 1145.8,696.4 1145.8,700.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1076.0,708.6 L1145.8,700.9 L1145.8,696.4 L1076.0,704.1 L1076.0,708.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1145.8,700.9 1145.8,696.4 1156.2,707.3 1156.2,711.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1145.8,700.9 L1156.2,711.8 L1156.2,707.3 L1145.8,696.4 L1145.8,700.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1145.8,700.9 1145.8,696.4 1156.2,707.3 1156.2,711.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1145.8,700.9 L1156.2,711.8 L1156.2,707.3 L1145.8,696.4 L1145.8,700.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1145.8,700.9 1145.8,696.4 1156.2,707.3 1156.2,711.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1145.8,700.9 L1156.2,711.8 L1156.2,707.3 L1145.8,696.4 L1145.8,700.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="822.4,712.5 822.4,699.1 892.2,691.4 892.2,704.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M822.4,712.5 L892.2,704.8 L892.2,691.4 L822.4,699.1 L822.4,712.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="822.4,712.5 822.4,699.1 892.2,691.4 892.2,704.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M822.4,712.5 L892.2,704.8 L892.2,691.4 L822.4,699.1 L822.4,712.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="822.4,712.5 822.4,699.1 892.2,691.4 892.2,704.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M822.4,712.5 L892.2,704.8 L892.2,691.4 L822.4,699.1 L822.4,712.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1076.0,704.1 1145.8,696.4 1156.2,707.3 1086.4,715.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1076.0,704.1 L1086.4,715.1 L1156.2,707.3 L1145.8,696.4 L1076.0,704.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1076.0,704.1 1145.8,696.4 1156.2,707.3 1086.4,715.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1076.0,704.1 L1086.4,715.1 L1156.2,707.3 L1145.8,696.4 L1076.0,704.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1076.0,704.1 1145.8,696.4 1156.2,707.3 1086.4,715.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1076.0,704.1 L1086.4,715.1 L1156.2,707.3 L1145.8,696.4 L1076.0,704.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="892.2,704.8 892.2,691.4 902.6,702.3 902.6,715.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M892.2,704.8 L902.6,715.7 L902.6,702.3 L892.2,691.4 L892.2,704.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="892.2,704.8 892.2,691.4 902.6,702.3 902.6,715.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M892.2,704.8 L902.6,715.7 L902.6,702.3 L892.2,691.4 L892.2,704.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="892.2,704.8 892.2,691.4 902.6,702.3 902.6,715.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M892.2,704.8 L902.6,715.7 L902.6,702.3 L892.2,691.4 L892.2,704.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="569.0,716.4 569.0,689.8 638.8,682.1 638.8,708.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M569.0,716.4 L638.8,708.7 L638.8,682.1 L569.0,689.8 L569.0,716.4  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="569.0,716.4 569.0,689.8 638.8,682.1 638.8,708.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M569.0,716.4 L638.8,708.7 L638.8,682.1 L569.0,689.8 L569.0,716.4  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="569.0,716.4 569.0,689.8 638.8,682.1 638.8,708.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M569.0,716.4 L638.8,708.7 L638.8,682.1 L569.0,689.8 L569.0,716.4  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1076.0,708.6 1076.0,704.1 1086.4,715.1 1086.4,719.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1076.0,708.6 L1086.4,719.5 L1086.4,715.1 L1076.0,704.1 L1076.0,708.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1076.0,708.6 1076.0,704.1 1086.4,715.1 1086.4,719.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1076.0,708.6 L1086.4,719.5 L1086.4,715.1 L1076.0,704.1 L1076.0,708.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1076.0,708.6 1076.0,704.1 1086.4,715.1 1086.4,719.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1076.0,708.6 L1086.4,719.5 L1086.4,715.1 L1076.0,704.1 L1076.0,708.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="822.4,699.1 892.2,691.4 902.6,702.3 832.8,710.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M822.4,699.1 L832.8,710.0 L902.6,702.3 L892.2,691.4 L822.4,699.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="822.4,699.1 892.2,691.4 902.6,702.3 832.8,710.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M822.4,699.1 L832.8,710.0 L902.6,702.3 L892.2,691.4 L822.4,699.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="822.4,699.1 892.2,691.4 902.6,702.3 832.8,710.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M822.4,699.1 L832.8,710.0 L902.6,702.3 L892.2,691.4 L822.4,699.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="638.8,708.7 638.8,682.1 649.2,693.0 649.2,719.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M638.8,708.7 L649.2,719.6 L649.2,693.0 L638.8,682.1 L638.8,708.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="638.8,708.7 638.8,682.1 649.2,693.0 649.2,719.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M638.8,708.7 L649.2,719.6 L649.2,693.0 L638.8,682.1 L638.8,708.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="638.8,708.7 638.8,682.1 649.2,693.0 649.2,719.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M638.8,708.7 L649.2,719.6 L649.2,693.0 L638.8,682.1 L638.8,708.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1086.4,719.5 1086.4,715.1 1156.2,707.3 1156.2,711.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1086.4,719.5 L1156.2,711.8 L1156.2,707.3 L1086.4,715.1 L1086.4,719.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1086.4,719.5 1086.4,715.1 1156.2,707.3 1156.2,711.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1086.4,719.5 L1156.2,711.8 L1156.2,707.3 L1086.4,715.1 L1086.4,719.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1086.4,719.5 1086.4,715.1 1156.2,707.3 1156.2,711.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1086.4,719.5 L1156.2,711.8 L1156.2,707.3 L1086.4,715.1 L1086.4,719.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="822.4,712.5 822.4,699.1 832.8,710.0 832.8,723.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M822.4,712.5 L832.8,723.4 L832.8,710.0 L822.4,699.1 L822.4,712.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="822.4,712.5 822.4,699.1 832.8,710.0 832.8,723.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M822.4,712.5 L832.8,723.4 L832.8,710.0 L822.4,699.1 L822.4,712.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="822.4,712.5 822.4,699.1 832.8,710.0 832.8,723.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M822.4,712.5 L832.8,723.4 L832.8,710.0 L822.4,699.1 L822.4,712.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="569.0,689.8 638.8,682.1 649.2,693.0 579.4,700.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M569.0,689.8 L579.4,700.8 L649.2,693.0 L638.8,682.1 L569.0,689.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="569.0,689.8 638.8,682.1 649.2,693.0 579.4,700.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M569.0,689.8 L579.4,700.8 L649.2,693.0 L638.8,682.1 L569.0,689.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="569.0,689.8 638.8,682.1 649.2,693.0 579.4,700.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M569.0,689.8 L579.4,700.8 L649.2,693.0 L638.8,682.1 L569.0,689.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="832.8,723.4 832.8,710.0 902.6,702.3 902.6,715.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M832.8,723.4 L902.6,715.7 L902.6,702.3 L832.8,710.0 L832.8,723.4  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="832.8,723.4 832.8,710.0 902.6,702.3 902.6,715.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M832.8,723.4 L902.6,715.7 L902.6,702.3 L832.8,710.0 L832.8,723.4  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="832.8,723.4 832.8,710.0 902.6,702.3 902.6,715.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M832.8,723.4 L902.6,715.7 L902.6,702.3 L832.8,710.0 L832.8,723.4  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="569.0,716.4 569.0,689.8 579.4,700.8 579.4,727.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M569.0,716.4 L579.4,727.3 L579.4,700.8 L569.0,689.8 L569.0,716.4  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="569.0,716.4 569.0,689.8 579.4,700.8 579.4,727.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M569.0,716.4 L579.4,727.3 L579.4,700.8 L569.0,689.8 L569.0,716.4  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="569.0,716.4 569.0,689.8 579.4,700.8 579.4,727.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M569.0,716.4 L579.4,727.3 L579.4,700.8 L569.0,689.8 L569.0,716.4  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="579.4,727.3 579.4,700.8 649.2,693.0 649.2,719.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M579.4,727.3 L649.2,719.6 L649.2,693.0 L579.4,700.8 L579.4,727.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="579.4,727.3 579.4,700.8 649.2,693.0 649.2,719.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M579.4,727.3 L649.2,719.6 L649.2,693.0 L579.4,700.8 L579.4,727.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="579.4,727.3 579.4,700.8 649.2,693.0 649.2,719.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M579.4,727.3 L649.2,719.6 L649.2,693.0 L579.4,700.8 L579.4,727.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1096.8,730.5 1096.8,723.8 1166.6,716.1 1166.6,722.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1096.8,730.5 L1166.6,722.7 L1166.6,716.1 L1096.8,723.8 L1096.8,730.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1096.8,730.5 1096.8,723.8 1166.6,716.1 1166.6,722.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1096.8,730.5 L1166.6,722.7 L1166.6,716.1 L1096.8,723.8 L1096.8,730.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1096.8,730.5 1096.8,723.8 1166.6,716.1 1166.6,722.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1096.8,730.5 L1166.6,722.7 L1166.6,716.1 L1096.8,723.8 L1096.8,730.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1166.6,722.7 1166.6,716.1 1177.0,727.0 1177.0,733.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1166.6,722.7 L1177.0,733.7 L1177.0,727.0 L1166.6,716.1 L1166.6,722.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1166.6,722.7 1166.6,716.1 1177.0,727.0 1177.0,733.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1166.6,722.7 L1177.0,733.7 L1177.0,727.0 L1166.6,716.1 L1166.6,722.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1166.6,722.7 1166.6,716.1 1177.0,727.0 1177.0,733.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1166.6,722.7 L1177.0,733.7 L1177.0,727.0 L1166.6,716.1 L1166.6,722.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="843.3,734.3 843.3,729.9 913.1,722.2 913.1,726.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M843.3,734.3 L913.1,726.6 L913.1,722.2 L843.3,729.9 L843.3,734.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="843.3,734.3 843.3,729.9 913.1,722.2 913.1,726.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M843.3,734.3 L913.1,726.6 L913.1,722.2 L843.3,729.9 L843.3,734.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="843.3,734.3 843.3,729.9 913.1,722.2 913.1,726.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M843.3,734.3 L913.1,726.6 L913.1,722.2 L843.3,729.9 L843.3,734.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1096.8,723.8 1166.6,716.1 1177.0,727.0 1107.2,734.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1096.8,723.8 L1107.2,734.7 L1177.0,727.0 L1166.6,716.1 L1096.8,723.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1096.8,723.8 1166.6,716.1 1177.0,727.0 1107.2,734.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1096.8,723.8 L1107.2,734.7 L1177.0,727.0 L1166.6,716.1 L1096.8,723.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1096.8,723.8 1166.6,716.1 1177.0,727.0 1107.2,734.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1096.8,723.8 L1107.2,734.7 L1177.0,727.0 L1166.6,716.1 L1096.8,723.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="913.1,726.6 913.1,722.2 923.5,733.1 923.5,737.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M913.1,726.6 L923.5,737.6 L923.5,733.1 L913.1,722.2 L913.1,726.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="913.1,726.6 913.1,722.2 923.5,733.1 923.5,737.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M913.1,726.6 L923.5,737.6 L923.5,733.1 L913.1,722.2 L913.1,726.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="913.1,726.6 913.1,722.2 923.5,733.1 923.5,737.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M913.1,726.6 L923.5,737.6 L923.5,733.1 L913.1,722.2 L913.1,726.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="589.8,738.2 589.8,731.5 659.6,723.8 659.6,730.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M589.8,738.2 L659.6,730.5 L659.6,723.8 L589.8,731.5 L589.8,738.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="589.8,738.2 589.8,731.5 659.6,723.8 659.6,730.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M589.8,738.2 L659.6,730.5 L659.6,723.8 L589.8,731.5 L589.8,738.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="589.8,738.2 589.8,731.5 659.6,723.8 659.6,730.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M589.8,738.2 L659.6,730.5 L659.6,723.8 L589.8,731.5 L589.8,738.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1096.8,730.5 1096.8,723.8 1107.2,734.7 1107.2,741.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1096.8,730.5 L1107.2,741.4 L1107.2,734.7 L1096.8,723.8 L1096.8,730.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1096.8,730.5 1096.8,723.8 1107.2,734.7 1107.2,741.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1096.8,730.5 L1107.2,741.4 L1107.2,734.7 L1096.8,723.8 L1096.8,730.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1096.8,730.5 1096.8,723.8 1107.2,734.7 1107.2,741.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1096.8,730.5 L1107.2,741.4 L1107.2,734.7 L1096.8,723.8 L1096.8,730.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="843.3,729.9 913.1,722.2 923.5,733.1 853.7,740.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M843.3,729.9 L853.7,740.8 L923.5,733.1 L913.1,722.2 L843.3,729.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="843.3,729.9 913.1,722.2 923.5,733.1 853.7,740.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M843.3,729.9 L853.7,740.8 L923.5,733.1 L913.1,722.2 L843.3,729.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="843.3,729.9 913.1,722.2 923.5,733.1 853.7,740.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M843.3,729.9 L853.7,740.8 L923.5,733.1 L913.1,722.2 L843.3,729.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="659.6,730.5 659.6,723.8 670.0,734.7 670.0,741.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M659.6,730.5 L670.0,741.4 L670.0,734.7 L659.6,723.8 L659.6,730.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="659.6,730.5 659.6,723.8 670.0,734.7 670.0,741.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M659.6,730.5 L670.0,741.4 L670.0,734.7 L659.6,723.8 L659.6,730.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="659.6,730.5 659.6,723.8 670.0,734.7 670.0,741.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M659.6,730.5 L670.0,741.4 L670.0,734.7 L659.6,723.8 L659.6,730.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1107.2,741.4 1107.2,734.7 1177.0,727.0 1177.0,733.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1107.2,741.4 L1177.0,733.7 L1177.0,727.0 L1107.2,734.7 L1107.2,741.4  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1107.2,741.4 1107.2,734.7 1177.0,727.0 1177.0,733.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1107.2,741.4 L1177.0,733.7 L1177.0,727.0 L1107.2,734.7 L1107.2,741.4  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1107.2,741.4 1107.2,734.7 1177.0,727.0 1177.0,733.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1107.2,741.4 L1177.0,733.7 L1177.0,727.0 L1107.2,734.7 L1107.2,741.4  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="843.3,734.3 843.3,729.9 853.7,740.8 853.7,745.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M843.3,734.3 L853.7,745.3 L853.7,740.8 L843.3,729.9 L843.3,734.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="843.3,734.3 843.3,729.9 853.7,740.8 853.7,745.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M843.3,734.3 L853.7,745.3 L853.7,740.8 L843.3,729.9 L843.3,734.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="843.3,734.3 843.3,729.9 853.7,740.8 853.7,745.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M843.3,734.3 L853.7,745.3 L853.7,740.8 L843.3,729.9 L843.3,734.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="589.8,731.5 659.6,723.8 670.0,734.7 600.2,742.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M589.8,731.5 L600.2,742.5 L670.0,734.7 L659.6,723.8 L589.8,731.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="589.8,731.5 659.6,723.8 670.0,734.7 600.2,742.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M589.8,731.5 L600.2,742.5 L670.0,734.7 L659.6,723.8 L589.8,731.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="589.8,731.5 659.6,723.8 670.0,734.7 600.2,742.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M589.8,731.5 L600.2,742.5 L670.0,734.7 L659.6,723.8 L589.8,731.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="853.7,745.3 853.7,740.8 923.5,733.1 923.5,737.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M853.7,745.3 L923.5,737.6 L923.5,733.1 L853.7,740.8 L853.7,745.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="853.7,745.3 853.7,740.8 923.5,733.1 923.5,737.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M853.7,745.3 L923.5,737.6 L923.5,733.1 L853.7,740.8 L853.7,745.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="853.7,745.3 853.7,740.8 923.5,733.1 923.5,737.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M853.7,745.3 L923.5,737.6 L923.5,733.1 L853.7,740.8 L853.7,745.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="589.8,738.2 589.8,731.5 600.2,742.5 600.2,749.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M589.8,738.2 L600.2,749.2 L600.2,742.5 L589.8,731.5 L589.8,738.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="589.8,738.2 589.8,731.5 600.2,742.5 600.2,749.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M589.8,738.2 L600.2,749.2 L600.2,742.5 L589.8,731.5 L589.8,738.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="589.8,738.2 589.8,731.5 600.2,742.5 600.2,749.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M589.8,738.2 L600.2,749.2 L600.2,742.5 L589.8,731.5 L589.8,738.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="600.2,749.2 600.2,742.5 670.0,734.7 670.0,741.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M600.2,749.2 L670.0,741.4 L670.0,734.7 L600.2,742.5 L600.2,749.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="600.2,749.2 600.2,742.5 670.0,734.7 670.0,741.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M600.2,749.2 L670.0,741.4 L670.0,734.7 L600.2,742.5 L600.2,749.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="600.2,749.2 600.2,742.5 670.0,734.7 670.0,741.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M600.2,749.2 L670.0,741.4 L670.0,734.7 L600.2,742.5 L600.2,749.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1117.7,752.3 1117.7,752.3 1187.5,744.5 1187.5,744.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M1117.7,752.3 L1187.5,744.6 L1187.5,744.5 L1117.7,752.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1117.7,752.3 1117.7,752.3 1187.5,744.5 1187.5,744.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M1117.7,752.3 L1187.5,744.6 L1187.5,744.5 L1117.7,752.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1117.7,752.3 1117.7,752.3 1187.5,744.5 1187.5,744.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M1117.7,752.3 L1187.5,744.6 L1187.5,744.5 L1117.7,752.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1187.5,744.6 1187.5,744.5 1197.9,755.5 1197.9,755.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M1187.5,744.6 L1197.9,755.5 L1187.5,744.5 L1187.5,744.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1187.5,744.6 1187.5,744.5 1197.9,755.5 1197.9,755.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M1187.5,744.6 L1197.9,755.5 L1187.5,744.5 L1187.5,744.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1187.5,744.6 1187.5,744.5 1197.9,755.5 1197.9,755.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M1187.5,744.6 L1197.9,755.5 L1187.5,744.5 L1187.5,744.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="864.1,756.2 864.1,749.5 933.9,741.8 933.9,748.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M864.1,756.2 L933.9,748.5 L933.9,741.8 L864.1,749.5 L864.1,756.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="864.1,756.2 864.1,749.5 933.9,741.8 933.9,748.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M864.1,756.2 L933.9,748.5 L933.9,741.8 L864.1,749.5 L864.1,756.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="864.1,756.2 864.1,749.5 933.9,741.8 933.9,748.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M864.1,756.2 L933.9,748.5 L933.9,741.8 L864.1,749.5 L864.1,756.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1117.7,752.3 1187.5,744.5 1197.9,755.5 1128.1,763.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1117.7,752.3 L1128.1,763.2 L1197.9,755.5 L1187.5,744.5 L1117.7,752.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1117.7,752.3 1187.5,744.5 1197.9,755.5 1128.1,763.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1117.7,752.3 L1128.1,763.2 L1197.9,755.5 L1187.5,744.5 L1117.7,752.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1117.7,752.3 1187.5,744.5 1197.9,755.5 1128.1,763.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1117.7,752.3 L1128.1,763.2 L1197.9,755.5 L1187.5,744.5 L1117.7,752.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="933.9,748.5 933.9,741.8 944.4,752.7 944.4,759.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M933.9,748.5 L944.4,759.4 L944.4,752.7 L933.9,741.8 L933.9,748.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="933.9,748.5 933.9,741.8 944.4,752.7 944.4,759.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M933.9,748.5 L944.4,759.4 L944.4,752.7 L933.9,741.8 L933.9,748.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="933.9,748.5 933.9,741.8 944.4,752.7 944.4,759.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M933.9,748.5 L944.4,759.4 L944.4,752.7 L933.9,741.8 L933.9,748.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="610.7,760.1 610.7,755.7 680.5,747.9 680.5,752.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M610.7,760.1 L680.5,752.4 L680.5,747.9 L610.7,755.7 L610.7,760.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="610.7,760.1 610.7,755.7 680.5,747.9 680.5,752.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M610.7,760.1 L680.5,752.4 L680.5,747.9 L610.7,755.7 L610.7,760.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="610.7,760.1 610.7,755.7 680.5,747.9 680.5,752.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M610.7,760.1 L680.5,752.4 L680.5,747.9 L610.7,755.7 L610.7,760.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1117.7,752.3 1117.7,752.3 1128.1,763.2 1128.1,763.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M1117.7,752.3 L1128.1,763.2 L1117.7,752.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1117.7,752.3 1117.7,752.3 1128.1,763.2 1128.1,763.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M1117.7,752.3 L1128.1,763.2 L1117.7,752.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1117.7,752.3 1117.7,752.3 1128.1,763.2 1128.1,763.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M1117.7,752.3 L1128.1,763.2 L1117.7,752.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="864.1,749.5 933.9,741.8 944.4,752.7 874.5,760.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M864.1,749.5 L874.5,760.5 L944.4,752.7 L933.9,741.8 L864.1,749.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="864.1,749.5 933.9,741.8 944.4,752.7 874.5,760.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M864.1,749.5 L874.5,760.5 L944.4,752.7 L933.9,741.8 L864.1,749.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="864.1,749.5 933.9,741.8 944.4,752.7 874.5,760.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M864.1,749.5 L874.5,760.5 L944.4,752.7 L933.9,741.8 L864.1,749.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="680.5,752.4 680.5,747.9 690.9,758.9 690.9,763.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M680.5,752.4 L690.9,763.3 L690.9,758.9 L680.5,747.9 L680.5,752.4  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="680.5,752.4 680.5,747.9 690.9,758.9 690.9,763.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M680.5,752.4 L690.9,763.3 L690.9,758.9 L680.5,747.9 L680.5,752.4  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="680.5,752.4 680.5,747.9 690.9,758.9 690.9,763.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M680.5,752.4 L690.9,763.3 L690.9,758.9 L680.5,747.9 L680.5,752.4  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1128.1,763.2 1128.1,763.2 1197.9,755.5 1197.9,755.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M1128.1,763.2 L1197.9,755.5 L1128.1,763.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1128.1,763.2 1128.1,763.2 1197.9,755.5 1197.9,755.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M1128.1,763.2 L1197.9,755.5 L1128.1,763.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1128.1,763.2 1128.1,763.2 1197.9,755.5 1197.9,755.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M1128.1,763.2 L1197.9,755.5 L1128.1,763.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="864.1,756.2 864.1,749.5 874.5,760.5 874.5,767.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M864.1,756.2 L874.5,767.1 L874.5,760.5 L864.1,749.5 L864.1,756.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="864.1,756.2 864.1,749.5 874.5,760.5 874.5,767.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M864.1,756.2 L874.5,767.1 L874.5,760.5 L864.1,749.5 L864.1,756.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="864.1,756.2 864.1,749.5 874.5,760.5 874.5,767.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M864.1,756.2 L874.5,767.1 L874.5,760.5 L864.1,749.5 L864.1,756.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="610.7,755.7 680.5,747.9 690.9,758.9 621.1,766.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M610.7,755.7 L621.1,766.6 L690.9,758.9 L680.5,747.9 L610.7,755.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="610.7,755.7 680.5,747.9 690.9,758.9 621.1,766.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M610.7,755.7 L621.1,766.6 L690.9,758.9 L680.5,747.9 L610.7,755.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="610.7,755.7 680.5,747.9 690.9,758.9 621.1,766.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M610.7,755.7 L621.1,766.6 L690.9,758.9 L680.5,747.9 L610.7,755.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="874.5,767.1 874.5,760.5 944.4,752.7 944.4,759.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M874.5,767.1 L944.4,759.4 L944.4,752.7 L874.5,760.5 L874.5,767.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="874.5,767.1 874.5,760.5 944.4,752.7 944.4,759.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M874.5,767.1 L944.4,759.4 L944.4,752.7 L874.5,760.5 L874.5,767.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="874.5,767.1 874.5,760.5 944.4,752.7 944.4,759.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M874.5,767.1 L944.4,759.4 L944.4,752.7 L874.5,760.5 L874.5,767.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="610.7,760.1 610.7,755.7 621.1,766.6 621.1,771.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M610.7,760.1 L621.1,771.0 L621.1,766.6 L610.7,755.7 L610.7,760.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="610.7,760.1 610.7,755.7 621.1,766.6 621.1,771.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M610.7,760.1 L621.1,771.0 L621.1,766.6 L610.7,755.7 L610.7,760.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="610.7,760.1 610.7,755.7 621.1,766.6 621.1,771.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M610.7,760.1 L621.1,771.0 L621.1,766.6 L610.7,755.7 L610.7,760.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="621.1,771.0 621.1,766.6 690.9,758.9 690.9,763.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M621.1,771.0 L690.9,763.3 L690.9,758.9 L621.1,766.6 L621.1,771.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="621.1,771.0 621.1,766.6 690.9,758.9 690.9,763.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M621.1,771.0 L690.9,763.3 L690.9,758.9 L621.1,766.6 L621.1,771.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="621.1,771.0 621.1,766.6 690.9,758.9 690.9,763.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M621.1,771.0 L690.9,763.3 L690.9,758.9 L621.1,766.6 L621.1,771.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1138.5,774.2 1138.5,773.6 1208.3,765.9 1208.3,766.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1138.5,774.2 L1208.3,766.5 L1208.3,765.9 L1138.5,773.6 L1138.5,774.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1138.5,774.2 1138.5,773.6 1208.3,765.9 1208.3,766.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1138.5,774.2 L1208.3,766.5 L1208.3,765.9 L1138.5,773.6 L1138.5,774.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1138.5,774.2 1138.5,773.6 1208.3,765.9 1208.3,766.5 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1138.5,774.2 L1208.3,766.5 L1208.3,765.9 L1138.5,773.6 L1138.5,774.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1208.3,766.5 1208.3,765.9 1218.8,776.8 1218.8,777.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1208.3,766.5 L1218.8,777.4 L1218.8,776.8 L1208.3,765.9 L1208.3,766.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1208.3,766.5 1208.3,765.9 1218.8,776.8 1218.8,777.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1208.3,766.5 L1218.8,777.4 L1218.8,776.8 L1208.3,765.9 L1208.3,766.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1208.3,766.5 1208.3,765.9 1218.8,776.8 1218.8,777.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1208.3,766.5 L1218.8,777.4 L1218.8,776.8 L1208.3,765.9 L1208.3,766.5  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="885.0,778.1 885.0,778.0 954.8,770.3 954.8,770.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M885.0,778.1 L954.8,770.3 L885.0,778.0 L885.0,778.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="885.0,778.1 885.0,778.0 954.8,770.3 954.8,770.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M885.0,778.1 L954.8,770.3 L885.0,778.0 L885.0,778.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="885.0,778.1 885.0,778.0 954.8,770.3 954.8,770.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M885.0,778.1 L954.8,770.3 L885.0,778.0 L885.0,778.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1138.5,773.6 1208.3,765.9 1218.8,776.8 1149.0,784.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1138.5,773.6 L1149.0,784.6 L1218.8,776.8 L1208.3,765.9 L1138.5,773.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1138.5,773.6 1208.3,765.9 1218.8,776.8 1149.0,784.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1138.5,773.6 L1149.0,784.6 L1218.8,776.8 L1208.3,765.9 L1138.5,773.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1138.5,773.6 1208.3,765.9 1218.8,776.8 1149.0,784.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1138.5,773.6 L1149.0,784.6 L1218.8,776.8 L1208.3,765.9 L1138.5,773.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="954.8,770.3 954.8,770.3 965.2,781.2 965.2,781.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M954.8,770.3 L965.2,781.3 L965.2,781.2 L954.8,770.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="954.8,770.3 954.8,770.3 965.2,781.2 965.2,781.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M954.8,770.3 L965.2,781.3 L965.2,781.2 L954.8,770.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="954.8,770.3 954.8,770.3 965.2,781.2 965.2,781.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M954.8,770.3 L965.2,781.3 L965.2,781.2 L954.8,770.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="631.5,781.9 631.5,775.3 701.3,767.6 701.3,774.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M631.5,781.9 L701.3,774.2 L701.3,767.6 L631.5,775.3 L631.5,781.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="631.5,781.9 631.5,775.3 701.3,767.6 701.3,774.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M631.5,781.9 L701.3,774.2 L701.3,767.6 L631.5,775.3 L631.5,781.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="631.5,781.9 631.5,775.3 701.3,767.6 701.3,774.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M631.5,781.9 L701.3,774.2 L701.3,767.6 L631.5,775.3 L631.5,781.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1138.5,774.2 1138.5,773.6 1149.0,784.6 1149.0,785.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1138.5,774.2 L1149.0,785.1 L1149.0,784.6 L1138.5,773.6 L1138.5,774.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1138.5,774.2 1138.5,773.6 1149.0,784.6 1149.0,785.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1138.5,774.2 L1149.0,785.1 L1149.0,784.6 L1138.5,773.6 L1138.5,774.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1138.5,774.2 1138.5,773.6 1149.0,784.6 1149.0,785.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1138.5,774.2 L1149.0,785.1 L1149.0,784.6 L1138.5,773.6 L1138.5,774.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="885.0,778.0 954.8,770.3 965.2,781.2 895.4,788.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M885.0,778.0 L895.4,788.9 L965.2,781.2 L954.8,770.3 L885.0,778.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="885.0,778.0 954.8,770.3 965.2,781.2 895.4,788.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M885.0,778.0 L895.4,788.9 L965.2,781.2 L954.8,770.3 L885.0,778.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="885.0,778.0 954.8,770.3 965.2,781.2 895.4,788.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M885.0,778.0 L895.4,788.9 L965.2,781.2 L954.8,770.3 L885.0,778.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="701.3,774.2 701.3,767.6 711.8,778.5 711.8,785.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M701.3,774.2 L711.8,785.2 L711.8,778.5 L701.3,767.6 L701.3,774.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="701.3,774.2 701.3,767.6 711.8,778.5 711.8,785.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M701.3,774.2 L711.8,785.2 L711.8,778.5 L701.3,767.6 L701.3,774.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="701.3,774.2 701.3,767.6 711.8,778.5 711.8,785.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M701.3,774.2 L711.8,785.2 L711.8,778.5 L701.3,767.6 L701.3,774.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1149.0,785.1 1149.0,784.6 1218.8,776.8 1218.8,777.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1149.0,785.1 L1218.8,777.4 L1218.8,776.8 L1149.0,784.6 L1149.0,785.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1149.0,785.1 1149.0,784.6 1218.8,776.8 1218.8,777.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1149.0,785.1 L1218.8,777.4 L1218.8,776.8 L1149.0,784.6 L1149.0,785.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(230, 159,   0)"
+                    points="1149.0,785.1 1149.0,784.6 1218.8,776.8 1218.8,777.4 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M1149.0,785.1 L1218.8,777.4 L1218.8,776.8 L1149.0,784.6 L1149.0,785.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="885.0,778.1 885.0,778.0 895.4,788.9 895.4,789.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M885.0,778.1 L895.4,789.0 L895.4,788.9 L885.0,778.0 L885.0,778.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="885.0,778.1 885.0,778.0 895.4,788.9 895.4,789.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M885.0,778.1 L895.4,789.0 L895.4,788.9 L885.0,778.0 L885.0,778.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="885.0,778.1 885.0,778.0 895.4,788.9 895.4,789.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M885.0,778.1 L895.4,789.0 L895.4,788.9 L885.0,778.0 L885.0,778.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="631.5,775.3 701.3,767.6 711.8,778.5 642.0,786.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M631.5,775.3 L642.0,786.2 L711.8,778.5 L701.3,767.6 L631.5,775.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="631.5,775.3 701.3,767.6 711.8,778.5 642.0,786.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M631.5,775.3 L642.0,786.2 L711.8,778.5 L701.3,767.6 L631.5,775.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="631.5,775.3 701.3,767.6 711.8,778.5 642.0,786.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M631.5,775.3 L642.0,786.2 L711.8,778.5 L701.3,767.6 L631.5,775.3  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="895.4,789.0 895.4,788.9 965.2,781.2 965.2,781.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M895.4,789.0 L965.2,781.3 L965.2,781.2 L895.4,788.9 L895.4,789.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="895.4,789.0 895.4,788.9 965.2,781.2 965.2,781.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M895.4,789.0 L965.2,781.3 L965.2,781.2 L895.4,788.9 L895.4,789.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="895.4,789.0 895.4,788.9 965.2,781.2 965.2,781.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M895.4,789.0 L965.2,781.3 L965.2,781.2 L895.4,788.9 L895.4,789.0  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="631.5,781.9 631.5,775.3 642.0,786.2 642.0,792.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M631.5,781.9 L642.0,792.9 L642.0,786.2 L631.5,775.3 L631.5,781.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="631.5,781.9 631.5,775.3 642.0,786.2 642.0,792.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M631.5,781.9 L642.0,792.9 L642.0,786.2 L631.5,775.3 L631.5,781.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="631.5,781.9 631.5,775.3 642.0,786.2 642.0,792.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M631.5,781.9 L642.0,792.9 L642.0,786.2 L631.5,775.3 L631.5,781.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="642.0,792.9 642.0,786.2 711.8,778.5 711.8,785.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M642.0,792.9 L711.8,785.2 L711.8,778.5 L642.0,786.2 L642.0,792.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="642.0,792.9 642.0,786.2 711.8,778.5 711.8,785.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M642.0,792.9 L711.8,785.2 L711.8,778.5 L642.0,786.2 L642.0,792.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="642.0,792.9 642.0,786.2 711.8,778.5 711.8,785.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M642.0,792.9 L711.8,785.2 L711.8,778.5 L642.0,786.2 L642.0,792.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="905.8,799.9 905.8,799.4 975.6,791.6 975.6,792.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M905.8,799.9 L975.6,792.2 L975.6,791.6 L905.8,799.4 L905.8,799.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="905.8,799.9 905.8,799.4 975.6,791.6 975.6,792.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M905.8,799.9 L975.6,792.2 L975.6,791.6 L905.8,799.4 L905.8,799.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="905.8,799.9 905.8,799.4 975.6,791.6 975.6,792.2 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M905.8,799.9 L975.6,792.2 L975.6,791.6 L905.8,799.4 L905.8,799.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="975.6,792.2 975.6,791.6 986.1,802.6 986.1,803.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M975.6,792.2 L986.1,803.1 L986.1,802.6 L975.6,791.6 L975.6,792.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="975.6,792.2 975.6,791.6 986.1,802.6 986.1,803.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M975.6,792.2 L986.1,803.1 L986.1,802.6 L975.6,791.6 L975.6,792.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="975.6,792.2 975.6,791.6 986.1,802.6 986.1,803.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M975.6,792.2 L986.1,803.1 L986.1,802.6 L975.6,791.6 L975.6,792.2  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="652.4,803.8 652.4,803.8 722.2,796.1 722.2,796.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M652.4,803.8 L722.2,796.1 L652.4,803.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="652.4,803.8 652.4,803.8 722.2,796.1 722.2,796.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M652.4,803.8 L722.2,796.1 L652.4,803.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="652.4,803.8 652.4,803.8 722.2,796.1 722.2,796.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M652.4,803.8 L722.2,796.1 L652.4,803.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="905.8,799.4 975.6,791.6 986.1,802.6 916.3,810.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M905.8,799.4 L916.3,810.3 L986.1,802.6 L975.6,791.6 L905.8,799.4  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="905.8,799.4 975.6,791.6 986.1,802.6 916.3,810.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M905.8,799.4 L916.3,810.3 L986.1,802.6 L975.6,791.6 L905.8,799.4  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="905.8,799.4 975.6,791.6 986.1,802.6 916.3,810.3 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M905.8,799.4 L916.3,810.3 L986.1,802.6 L975.6,791.6 L905.8,799.4  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="722.2,796.1 722.2,796.1 732.6,807.0 732.6,807.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M722.2,796.1 L732.6,807.0 L722.2,796.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="722.2,796.1 722.2,796.1 732.6,807.0 732.6,807.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M722.2,796.1 L732.6,807.0 L722.2,796.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="722.2,796.1 722.2,796.1 732.6,807.0 732.6,807.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M722.2,796.1 L732.6,807.0 L722.2,796.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="905.8,799.9 905.8,799.4 916.3,810.3 916.3,810.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M905.8,799.9 L916.3,810.8 L916.3,810.3 L905.8,799.4 L905.8,799.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="905.8,799.9 905.8,799.4 916.3,810.3 916.3,810.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M905.8,799.9 L916.3,810.8 L916.3,810.3 L905.8,799.4 L905.8,799.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="905.8,799.9 905.8,799.4 916.3,810.3 916.3,810.8 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M905.8,799.9 L916.3,810.8 L916.3,810.3 L905.8,799.4 L905.8,799.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="652.4,803.8 722.2,796.1 732.6,807.0 662.8,814.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M652.4,803.8 L662.8,814.7 L732.6,807.0 L722.2,796.1 L652.4,803.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="652.4,803.8 722.2,796.1 732.6,807.0 662.8,814.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M652.4,803.8 L662.8,814.7 L732.6,807.0 L722.2,796.1 L652.4,803.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="652.4,803.8 722.2,796.1 732.6,807.0 662.8,814.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M652.4,803.8 L662.8,814.7 L732.6,807.0 L722.2,796.1 L652.4,803.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="916.3,810.8 916.3,810.3 986.1,802.6 986.1,803.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M916.3,810.8 L986.1,803.1 L986.1,802.6 L916.3,810.3 L916.3,810.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="916.3,810.8 916.3,810.3 986.1,802.6 986.1,803.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M916.3,810.8 L986.1,803.1 L986.1,802.6 L916.3,810.3 L916.3,810.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb( 86, 180, 233)"
+                    points="916.3,810.8 916.3,810.3 986.1,802.6 986.1,803.1 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M916.3,810.8 L986.1,803.1 L986.1,802.6 L916.3,810.3 L916.3,810.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="652.4,803.8 652.4,803.8 662.8,814.7 662.8,814.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M652.4,803.8 L662.8,814.7 L652.4,803.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="652.4,803.8 652.4,803.8 662.8,814.7 662.8,814.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M652.4,803.8 L662.8,814.7 L652.4,803.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="652.4,803.8 652.4,803.8 662.8,814.7 662.8,814.7 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M652.4,803.8 L662.8,814.7 L652.4,803.8  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="662.8,814.7 662.8,814.7 732.6,807.0 732.6,807.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M662.8,814.7 L732.6,807.0 L662.8,814.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="662.8,814.7 662.8,814.7 732.6,807.0 732.6,807.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M662.8,814.7 L732.6,807.0 L662.8,814.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="662.8,814.7 662.8,814.7 732.6,807.0 732.6,807.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M662.8,814.7 L732.6,807.0 L662.8,814.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="673.2,825.7 673.2,825.1 743.0,817.4 743.0,817.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M673.2,825.7 L743.0,817.9 L743.0,817.4 L673.2,825.1 L673.2,825.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="673.2,825.7 673.2,825.1 743.0,817.4 743.0,817.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M673.2,825.7 L743.0,817.9 L743.0,817.4 L673.2,825.1 L673.2,825.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="673.2,825.7 673.2,825.1 743.0,817.4 743.0,817.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M673.2,825.7 L743.0,817.9 L743.0,817.4 L673.2,825.1 L673.2,825.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="743.0,817.9 743.0,817.4 753.5,828.3 753.5,828.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M743.0,817.9 L753.5,828.9 L753.5,828.3 L743.0,817.4 L743.0,817.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="743.0,817.9 743.0,817.4 753.5,828.3 753.5,828.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M743.0,817.9 L753.5,828.9 L753.5,828.3 L743.0,817.4 L743.0,817.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="743.0,817.9 743.0,817.4 753.5,828.3 753.5,828.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M743.0,817.9 L753.5,828.9 L753.5,828.3 L743.0,817.4 L743.0,817.9  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="673.2,825.1 743.0,817.4 753.5,828.3 683.7,836.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M673.2,825.1 L683.7,836.0 L753.5,828.3 L743.0,817.4 L673.2,825.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="673.2,825.1 743.0,817.4 753.5,828.3 683.7,836.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M673.2,825.1 L683.7,836.0 L753.5,828.3 L743.0,817.4 L673.2,825.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="673.2,825.1 743.0,817.4 753.5,828.3 683.7,836.0 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M673.2,825.1 L683.7,836.0 L753.5,828.3 L743.0,817.4 L673.2,825.1  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="673.2,825.7 673.2,825.1 683.7,836.0 683.7,836.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M673.2,825.7 L683.7,836.6 L683.7,836.0 L673.2,825.1 L673.2,825.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="673.2,825.7 673.2,825.1 683.7,836.0 683.7,836.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M673.2,825.7 L683.7,836.6 L683.7,836.0 L673.2,825.1 L673.2,825.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="673.2,825.7 673.2,825.1 683.7,836.0 683.7,836.6 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M673.2,825.7 L683.7,836.6 L683.7,836.0 L673.2,825.1 L673.2,825.7  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="683.7,836.6 683.7,836.0 753.5,828.3 753.5,828.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M683.7,836.6 L753.5,828.9 L753.5,828.3 L683.7,836.0 L683.7,836.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="683.7,836.6 683.7,836.0 753.5,828.3 753.5,828.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M683.7,836.6 L753.5,828.9 L753.5,828.3 L683.7,836.0 L683.7,836.6  "/>
+            <g stroke="none" shape-rendering="crispEdges">
+                <polygon fill="rgb(  0, 158, 115)"
+                    points="683.7,836.6 683.7,836.0 753.5,828.3 753.5,828.9 "/>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black"
+                d="M683.7,836.6 L753.5,828.9 L753.5,828.3 L683.7,836.0 L683.7,836.6  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M1416.5,755.6 L485.8,858.6  "/>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <path stroke="black" d="M183.4,541.6 L485.8,858.6  "/>
+            <g transform="translate(192.0,760.1)" stroke="none" fill="black" font-family="arial"
+                font-size="15.00" text-anchor="middle">
+                <text><tspan font-family="arial">Wf Ops</tspan></text>
+            </g>
+            <g transform="translate(986.2,847.0)" stroke="none" fill="black" font-family="arial"
+                font-size="15.00" text-anchor="middle">
+                <text><tspan font-family="arial">Workflows</tspan></text>
+            </g>
+            <g transform="translate(92.6,331.4)" stroke="none" fill="black" font-family="arial"
+                font-size="15.00" text-anchor="middle">
+                <text><tspan font-family="arial">Op Time [s]</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter">
+            <g transform="translate(800.0,33.9)" stroke="none" fill="black" font-family="arial"
+                font-size="15.00" text-anchor="middle">
+                <text><tspan font-family="arial">Workflow Operation Times</tspan></text>
+            </g>
+        </g>
+        <g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="butt"
+            stroke-linejoin="miter"> </g>
+    </g>
+</svg>

--- a/visualize-workflow/get-workflow.sh
+++ b/visualize-workflow/get-workflow.sh
@@ -6,4 +6,4 @@ HOST=https://develop.opencast.org
 ID=$1
 
 curl -f --digest -u "${LOGIN}" -H "X-Requested-Auth: Digest" \
-  -o workflow.json "${HOST}/workflow/instance/${ID}.json"
+  -o "workflow-${ID}.json" "${HOST}/workflow/instance/${ID}.json"

--- a/visualize-workflow/plot-mulit-workflow-3D.gnuplot
+++ b/visualize-workflow/plot-mulit-workflow-3D.gnuplot
@@ -1,0 +1,54 @@
+# Opencast Visualize Workflow Help utilities
+# This is a Demo of 3D plotting multiple instances of workflows with the same set of operations
+# Requires gnuplot 5.5+ for 3D charting
+# Based on 3D bar chart demo from http://gnuplot.sourceforge.net/demo_5.3/boxes3d.6.gnu
+# One of many future TODOs:
+# Conditionally label large operation times (aka '' using 0:3:5 with labels offset 0,0.5 notitle)
+
+set terminal svg size 1600,900 font "arial,10" fontscale 1.5 #size 1600, 800
+set output 'workflows-3D.svg'
+
+set boxwidth 0.5
+set boxdepth 0.3
+set style fill  solid 1.00 border
+set grid nopolar
+
+set grid xtics nomxtics ytics nomytics ztics nomztics nortics nomrtics \
+ nox2tics nomx2tics noy2tics nomy2tics nocbtics nomcbtics
+
+set style fill solid 1.0 border -1
+set xlabel "Wf Ops" offset -5, -3
+set ylabel "Workflows"
+set zlabel "Op Time [s]" offset -6,1
+
+# Expects workflow data files to be named "workflow<n>.dat", incremented 1-N
+
+WF_COUNT = 3
+file(n) = sprintf("workflow%d.dat",n)
+
+# Limit one label-key for each workflow file (not one for each wf-op block)
+getTitle(col,f) = col == 1 ? file(f) : ""
+
+set xtics offset 0, -0.5
+set ytics offset 0, -0.5
+set grid vertical layerdefault   lt 0 linecolor 0 linewidth 1.000,  lt 0 linecolor 0 linewidth 1.000
+set wall z0  fc  rgb "slategrey"  fillstyle  transparent solid 0.50 border lt -1
+set view 50, 72, 1.1, 1 # rotated to prevent long wf operation names from overlapping
+set style data lines
+set xyplane at 0
+set title "Workflow Operation Times"
+set xrange [ * : * ] noreverse writeback
+set x2range [ * : * ] noreverse writeback
+set yrange [0: WF_COUNT + 1]
+set y2range [ * : * ] noreverse writeback
+set zrange [ * : * ] noreverse writeback
+set cbrange [ * : * ] noreverse writeback
+set rrange [ * : * ] noreverse writeback
+set pm3d depthorder base
+set pm3d interpolate 1,1 flush begin noftriangles border linewidth 1.000 dashtype solid corners2color mean
+set pm3d lighting primary 0.5 specular 0.2 spec2 0
+NO_ANIMATION = 1
+
+# Plot expects first column of input to be wf-op names, third column to be time in seconds of the operation
+splot for [f=1:WF_COUNT] for [col=1:3] file(f) using 0:(f):3:xticlabels(1) with boxes lt f+1 title getTitle(col,f),
+

--- a/visualize-workflow/plot-workflow.gnuplot
+++ b/visualize-workflow/plot-workflow.gnuplot
@@ -1,10 +1,26 @@
-#set terminal svg size 1600,900
-set terminal svg size 1600,900 standalone fname 'Sans bold' fsize 20 background rgb 'white'
+# Plot individual Workflow Operation Charts
+# Change WF_COUNT to the number of workflows to process
+# Expects workflow data files to be named "workflow<n>.dat", incremented 1-N
+
+WF_COUNT = 1
+file(n) = sprintf("workflow%d.dat",n)
+
+set terminal svg size 1600,WF_COUNT * 900 font "Sans bold, 20" background rgb 'white'
+set output 'workflow.svg'
+
+
+set multiplot layout WF_COUNT, 1
+
 set boxwidth 0.8
 set style fill solid 1.0 border -1
 set xtics rotate
 set ylabel "Time [s]"
-set output 'workflow.svg'
-plot 'workflow.dat' using 3:xticlabels(1) with boxes lt rgb "#000000" notitle,\
-  '' using 0:3:5 with labels offset 0,0.5 notitle
-# Use "using 0:3:4" for percentages of the overall time
+
+do for [f=1:WF_COUNT] {
+  set title "Workflow Operation Times from ".file(f)
+  plot file(f) using 3:xticlabels(1) with boxes lt rgb "#000000" notitle,\
+    '' using 0:3:5 with labels offset 0,0.5 notitle
+  # Use "using 0:3:4" for percentages of the overall time
+}
+
+unset multiplot

--- a/visualize-workflow/prep-workflow.py
+++ b/visualize-workflow/prep-workflow.py
@@ -1,10 +1,18 @@
 #!/usr/bin/env python
 
 import json
+import glob
 
 
 def main():
-    with open('workflow.json', 'r') as f:
+    fileNum = 0
+    for file in glob.glob("*.json"):
+        fileNum += 1
+        prep(file, fileNum)
+
+
+def prep(wFfile, fileNum):
+    with open(wFfile, 'r') as f:
         instance = json.load(f)
 
     operations = []
@@ -23,7 +31,7 @@ def main():
 
         operations.append((id, state, duration))
 
-    with open('workflow.dat', 'w') as f:
+    with open('workflow' + str(fileNum) + '.dat', 'w') as f:
         for op in operations:
             percent = op[2] * 100.0 / runtime
             seconds = op[2]

--- a/visualize-workflow/readme.md
+++ b/visualize-workflow/readme.md
@@ -23,3 +23,42 @@ gnuplot plot-workflow.gnuplot
 ```
 
 This will produce a `workflow.svg`.
+
+Example Visualize Workflows chart:
+![Visualize Workflow Example](example-workflow.svg "Visualize Workflow Example")
+
+Compare Workflows 3D Bar Chart
+-----
+A second plotting file provides visual comparison of multiple workflow instances of the same type of workflow in a 3D bar chart. It helps identify processing differences resulting from variable input file types using the same workflow.
+
+This plot requires gnuplot v5.5+. The workflows being compared must have the **same** number and ordering of workflow operations. The 3D plotter cannot plot workflows that contain different operations or operations in a different order.
+
+Usage
+-----
+Set your system's location and digest login credentials in
+`./get-workflow.sh`.
+
+Then, get the identifier for the workflows you want to visualize from the event details of Opencast's admin interface.
+
+Then, modify the value of `WF_COUNT` to match the number of workflow instances to compare. The variable is located in both `./plot-mulit-workflow-3D.gnuplot` and `./plot-workflow.gnuplot`.
+
+Finally, Run the tool-chain (substitute with real workflow identifiers):
+
+```bash
+./get-workflow.sh <wfId 1>
+./get-workflow.sh <wfId 2>
+./get-workflow.sh <wfId 3>
+./get-workflow.sh <wfId 4>
+./get-workflow.sh <wfId etc>
+./prep-workflow.py
+gnuplot plot-workflow.gnuplot
+gnuplot plot-mulit-workflow-3D.gnuplot
+```
+
+This will produce a `workflow.svg` and a `workflows-3D.svg`
+
+The HTML helper file can be used to display the new SVG files, `./viewSvg.html`.
+
+
+Example Compare Workflows chart:
+![Workflows 3D Example](example-workflows-3D.svg "Workflows 3D Example")

--- a/visualize-workflow/viewSvg.html
+++ b/visualize-workflow/viewSvg.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title></title>
+    </head>
+    <body>
+        <div>2D Workflow Operation Time SVG</div>
+        <div>
+            <object data="workflow.svg" type="image/svg+xml"> </object>
+        </div>
+        <div>3D Workflows Operation Times SVG</div>
+        <div>
+            <object data="workflows-3D.svg" type="image/svg+xml"> </object>
+        </div>
+    </body>
+</html>


### PR DESCRIPTION
The pull modifies the existing gnuplot to have the ability to iterate over multiple inputs to output   multiple charts in the output svg. Instead of the just  one. 

A new gnuplot file is added to visually compare multiple workflows on one 3D chart. It has limitations in that the number and order of workflow operations must match in all workflows files being compared and it does not display the specific operation times in the chart.