### PR TITLE
Update LTI Consumer docs

### DIFF
--- a/lti-test-consumer/readme.md
+++ b/lti-test-consumer/readme.md
@@ -11,7 +11,7 @@ virtualenv venv
 . ./venv/bin/activate
 
 # install requirements
-pip install -r requirements.txt
+pip3 install -r requirements.txt
 
 # run test consumer
 python3 lticonsumer.py


### PR DESCRIPTION
Updating lti consumer docs to install bits via pip3 since python3 is also required, at least on my Debian 10 box.