### PR TITLE
Script to Export Videos

### DIFF
--- a/export-videos/README.md
+++ b/export-videos/README.md
@@ -13,6 +13,7 @@ First you need to configure the script in `config.py`:
 | `url`                 | The (tenant-specific) server URL                                         | https://tenant.opencast.com |
 | `digest_user`         | The user name of the digest user                                         | opencast_system_account     |
 | `digest_pw`           | The password of the digest user                                          | CHANGE_ME                   |
+| `stream_security`     | Whether to sign the URLs before downloading                              | False                       |
 | `target_directory`    | The path to the directory for the exported videos                        | /home/user/Desktop/videos   |
 | `export_archived`     | Whether to export archived tracks                                        | True                        |
 | `export_publications` | The publication channel(s) for which published tracks should be exported | \["engage-player"\]         |

--- a/export-videos/README.md
+++ b/export-videos/README.md
@@ -1,0 +1,46 @@
+# Script to export videos
+
+With this script, you can export archived or published video tracks from Opencast.
+
+## How to Use
+
+### Configuration
+
+First you need to configure the script in `config.py`:
+
+| Configuration Key     | Description                                                              | Example                     |
+| :-------------------- | :----------------------------------------------------------------------- | :-------------------------- |
+| `url`                 | The (tenant-specific) server URL                                         | https://tenant.opencast.com |
+| `digest_user`         | The user name of the digest user                                         | opencast_system_account     |
+| `digest_pw`           | The password of the digest user                                          | CHANGE_ME                   |
+| `target_directory`    | The path to the directory for the exported videos                        | /home/user/Desktop/videos   |
+| `export_archived`     | Whether to export archived tracks                                        | True                        |
+| `export_publications` | The publication channel(s) for which published tracks should be exported | \["engage-player"\]         |
+| `export_mimetypes`    | The type(s) of video to export (empty: all types)                        | \["video/mp4"]\             |
+| `export_flavors`      | The flavor(s) to export (empty: all flavors)                             | \["delivery/*"\]            |
+| `create_series_dirs`  | Whether to create a directory for each series when using the `-s`option  | False                       |
+
+### Usage
+
+The script can be called with the following parameters (all parameters in brackets are optional):
+
+`main.py [-e EVENT_ID [EVENT_ID ...]] [-s SERIES_ID [SERIES_ID ...]]`
+
+Either event ids (`-e`) or series ids (`-s`) have to be provided, but not both.
+
+| Short Option | Long Option | Description                                                     |
+| :----------: | :---------- | :-------------------------------------------------------------- |
+| `-e`         | `--events`  | The id(s) of the event(s) to be exported                        |
+| `-s`         | `--series`  | The id(s) of the series with events to be exported              |
+
+#### Usage example
+
+`main.py -e fe8cf34d-c6e9-4dc8-adaa-402dcae0532a 7b42129d-f286-4e66-8dc5-ade8fc882ae6`
+
+## Requirements
+
+This script was written for Python 3.8. You can install the necessary packages with
+
+`pip install -r requirements.txt`
+
+Additionally, this script uses modules contained in the _lib_ directory.

--- a/export-videos/config.py
+++ b/export-videos/config.py
@@ -5,6 +5,7 @@ target_directory = "/home/user/Desktop/videos"  # CHANGE ME
 create_series_dirs = False
 digest_user = "opencast_system_account"
 digest_pw = "CHANGE_ME"  # CHANGE ME
+stream_security = False
 
 # export settings
 export_archived = True

--- a/export-videos/config.py
+++ b/export-videos/config.py
@@ -1,0 +1,13 @@
+# Configuration
+
+url = "https://tenant.opencast.com"  # CHANGE ME
+target_directory = "/home/user/Desktop/videos"  # CHANGE ME
+create_series_dirs = False
+digest_user = "opencast_system_account"
+digest_pw = "CHANGE_ME"  # CHANGE ME
+
+# export settings
+export_archived = True
+export_publications = ["engage-player"]
+export_mimetypes = ["video/mp4"]
+export_flavors = []

--- a/export-videos/export_videos.py
+++ b/export-videos/export_videos.py
@@ -1,0 +1,105 @@
+import os
+
+from data_handling.flavor_matcher import matches_flavor
+from rest_requests.file_requests import get_video_file
+from rest_requests.stream_security_requests import sign_url
+
+
+def export_videos(mp, mp_dir, server_url, digest_login, export_archived, export_publications, export_mimetypes,
+                  export_flavors, sign=False):
+    """
+    Request the tracks of the media package that meet the criteria and export them to video files.
+
+    :param mp: The media package whose tracks should be exported
+    :type mp: MediaPackage
+    :param mp_dir: The directory for the media package
+    :type mp_dir: Path
+    :param export_archived: Whether to export archived tracks
+    :type export_archived: bool
+    :param export_publications: The publications to be exported
+    :type export_publications: list
+    :param export_mimetypes: The mimetypes to be exported
+    :type export_mimetypes: list
+    :param export_flavors: The flavors to be exported
+    :type export_flavors: list
+    :param server_url: The server URL
+    :type server_url: str
+    :param digest_login: The login credentials for digest authentication
+    :type digest_login: DigestLogin
+    :param sign: Whether to sign the URL first
+    :type sign: bool
+    """
+
+    # check archived tracks
+    if export_archived:
+        target_dir = os.path.join(mp_dir, 'archived')
+
+        for track in mp.tracks:
+            if __check_track(track, export_mimetypes, export_flavors):
+                try:
+                    __export_track(target_dir, track, server_url, digest_login, sign)
+                except Exception as e:
+                    print("Archived Track {} of media package {} could not be exported: {}"
+                          .format(track.id, mp.id, str(e)))
+
+    # check published tracks
+    if export_publications:
+        for publication in mp.publications:
+            if publication.channel in export_publications:
+                target_dir = os.path.join(mp_dir, publication.channel)
+
+                for track in publication.tracks:
+                    if __check_track(track, export_mimetypes, export_flavors):
+                        try:
+                            __export_track(target_dir, track, server_url, digest_login, sign)
+                        except Exception as e:
+                            print("Track {} of publication {} of media package {} could not be exported: {}"
+                                  .format(track.id, publication.channel, mp.id, str(e)))
+
+
+def __check_track(track, export_mimetypes, export_flavors):
+    """
+    Check if track meets criteria for export.
+
+    :param track: The track to be checked
+    :type track: Asset
+    :param export_mimetypes: The mimetypes to be exported
+    :type export_mimetypes: list
+    :param export_flavors: The flavors to be exported
+    :type export_flavors: list
+    :return: If the track should be exported.
+    :rtype: bool
+    """
+    return (not export_mimetypes or track.mimetype in export_mimetypes) and \
+           (not export_flavors or matches_flavor(track.flavor, export_flavors))
+
+
+def __export_track(target_dir, track, server_url, digest_login, sign=False):
+    """
+    Request a video and write it to a file. Sign the URL first if necessary.
+
+    :param target_dir: The directory to put the video file in
+    :type target_dir: Path
+    :param track: The track to be exported
+    :type track: Asset
+    :param server_url: The server URL
+    :type server_url: str
+    :param digest_login: The login credentials for digest authentication
+    :type digest_login: DigestLogin
+    :param sign: Whether to sign the URL first
+    :type sign: bool
+    :raise: RequestError
+    """
+
+    url = track.url
+
+    file_extension = url.split(".")[-1]
+    filename = '{}.{}'.format(track.id, file_extension)
+    path = os.path.join(target_dir, filename)
+
+    if sign:
+        url = sign_url(digest_login, server_url, url)
+
+    os.makedirs(target_dir, exist_ok=True)
+
+    get_video_file(digest_login, url, path)

--- a/export-videos/main.py
+++ b/export-videos/main.py
@@ -1,0 +1,77 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.abspath('..'), "lib"))
+
+import config
+from args.digest_login import DigestLogin
+from data_handling.elements import get_id
+from data_handling.parse_manifest import parse_manifest_from_endpoint
+from export_videos import export_videos
+from parse_args import parse_args
+from rest_requests.api_requests import get_events_of_series
+from rest_requests.assetmanager_requests import get_media_package
+
+
+def main():
+    """
+    Export video files
+    """
+
+    event_ids, series_ids = parse_args()
+    digest_login = DigestLogin(user=config.digest_user, password=config.digest_pw)
+
+    # get events from all series
+    if series_ids:
+        print("Getting events for series.")
+        events = []
+        for series_id in series_ids:
+            try:
+                events_of_series = get_events_of_series(config.url, digest_login, series_id)
+                events += events_of_series
+            except Exception as e:
+                print("Events of series {} could not be requested: {}".format(series_id, str(e)))
+
+        if not events:
+            __abort_script("No events found.")
+
+        event_ids = [get_id(event) for event in events]
+
+    print("Starting export process.")
+    for event_id in event_ids:
+        try:
+            print("Exporting videos of media package {}".format(event_id))
+
+            mp_xml = get_media_package(config.url, digest_login, event_id)
+
+            mp = parse_manifest_from_endpoint(mp_xml, event_id, False, True)
+
+            if config.create_series_dirs and mp.series_id:
+                mp_dir = os.path.join(config.target_directory, mp.series_id, mp.id)
+            else:
+                mp_dir = os.path.join(config.target_directory, mp.id)
+            export_videos(mp, mp_dir, config.url, digest_login, config.export_archived, config.export_publications,
+                          config.export_mimetypes, config.export_flavors, True)
+
+        except Exception as e:
+            print("Tracks of media package {} could not be exported: {}".format(event_id, str(e)))
+
+    print("Done.")
+
+
+def __abort_script(message):
+    """
+    Print message and abort script.
+    :param message: The error message
+    :type message: str
+    """
+    print(message)
+    sys.exit()
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except KeyboardInterrupt:
+        print("\nAborting process.")
+        sys.exit(0)

--- a/export-videos/main.py
+++ b/export-videos/main.py
@@ -51,7 +51,7 @@ def main():
             else:
                 mp_dir = os.path.join(config.target_directory, mp.id)
             export_videos(mp, mp_dir, config.url, digest_login, config.export_archived, config.export_publications,
-                          config.export_mimetypes, config.export_flavors, True)
+                          config.export_mimetypes, config.export_flavors, config.stream_security)
 
         except Exception as e:
             print("Tracks of media package {} could not be exported: {}".format(event_id, str(e)))

--- a/export-videos/parse_args.py
+++ b/export-videos/parse_args.py
@@ -1,0 +1,25 @@
+from args.args_parser import get_args_parser
+from args.args_error import args_error
+
+
+def parse_args():
+    """
+    Parse the arguments and check them for correctness
+
+    :return: list of event ids, list of series ids (one of them will be None)
+    :rtype: list, list
+    """
+    parser, optional_args, required_args = get_args_parser()
+
+    optional_args.add_argument("-e", "--events", type=str, nargs='+', help="list of event ids")
+    optional_args.add_argument("-s", "--series", type=str, nargs='+', help="list of series ids")
+
+    args = parser.parse_args()
+
+    if args.events and args.series:
+        args_error(parser, "You can only provide either events or series, not both")
+
+    if not args.events and not args.series:
+        args_error(parser, "You have to provide at least one series or event id")
+
+    return args.events, args.series

--- a/export-videos/requirements.txt
+++ b/export-videos/requirements.txt
@@ -1,0 +1,6 @@
+certifi==2020.6.20
+chardet==3.0.4
+idna==2.10
+requests==2.24.0
+requests-toolbelt==0.9.1
+urllib3==1.25.11

--- a/lib/data_handling/flavor_matcher.py
+++ b/lib/data_handling/flavor_matcher.py
@@ -1,0 +1,40 @@
+def __split_flavor(flavor):
+    """
+    Split a flavor into type and subtype.
+
+    :param flavor: The flavor to split
+    :type flavor: str
+    :return: type, subtype
+    :rtype: str, str
+    :raise: ValueError
+    """
+    flavor_types = flavor.split("/")
+    if len(flavor_types) != 2:
+        raise ValueError("Invalid flavor")
+
+    flavor_type = flavor_types[0]
+    flavor_subtype = flavor_types[1]
+    return flavor_type, flavor_subtype
+
+
+def matches_flavor(asset_flavor, config_flavors):
+    """
+    Check if a flavor matches the flavors in a list. The latter can contain the placeholder "*".
+
+    :param asset_flavor: The flavor to check
+    :type asset_flavor: str
+    :param config_flavors: The flavors to match (can contain "*")
+    :type config_flavors: list
+    :return: Whether the flavor matches.
+    :rtype: bool
+    """
+
+    asset_flavor_type, asset_flavor_subtype = __split_flavor(asset_flavor)
+    for config_flavor in config_flavors:
+        config_flavor_type, config_flavor_subtype = __split_flavor(config_flavor)
+
+        if (config_flavor_type == "*" or config_flavor_type == asset_flavor_type) and \
+           (config_flavor_subtype == "*" or config_flavor_subtype == asset_flavor_subtype):
+            return True
+
+    return False

--- a/lib/data_handling/parse_manifest.py
+++ b/lib/data_handling/parse_manifest.py
@@ -6,10 +6,13 @@ import os
 from data_handling.errors import MediaPackageError, optional_mp_error
 
 namespaces = {'manifest': 'http://mediapackage.opencastproject.org'}
-Element = namedtuple('Element', ['id', 'flavor', 'mimetype', 'filename', 'path', 'tags', 'url'])
+
+Asset = namedtuple('Asset', ['id', 'flavor', 'mimetype', 'filename', 'path', 'tags', 'url'])
+Publication = namedtuple('Publication', ['channel', 'tracks', 'attachments', 'catalogs'])
+MediaPackage = namedtuple('MediaPackage', ['id', 'series_id', 'tracks', 'attachments', 'catalogs', 'publications'])
 
 
-def parse_manifest_from_endpoint(manifest, mp_id, ignore_errors=False):
+def parse_manifest_from_endpoint(manifest, mp_id, ignore_errors=False, with_publications=False):
     """
     Parse the media package and collect the media package elements with all relevant information.
 
@@ -19,8 +22,10 @@ def parse_manifest_from_endpoint(manifest, mp_id, ignore_errors=False):
     :type mp_id: str
     :param ignore_errors: Whether to ignore errors and recover the media package anyway
     :type ignore_errors: bool
-    :return: series id, tracks, catalogs, attachments
-    :rtype: str, list, list, list
+    :param with_publications: Whether to include publication elements
+    :type with_publications: bool
+    :return: The MediaPackage
+    :rtype: MediaPackage
     :raise MediaPackageError:
     """
     try:
@@ -28,19 +33,21 @@ def parse_manifest_from_endpoint(manifest, mp_id, ignore_errors=False):
     except Exception:
         raise MediaPackageError("Media package {} could not be parsed.".format(mp_id))
 
-    return __parse_manifest(manifest, mp_id, None, ignore_errors)
+    return __parse_manifest(manifest, mp_id, None, ignore_errors, with_publications)
 
 
-def parse_manifest_from_filesystem(mp, ignore_errors=False):
+def parse_manifest_from_filesystem(mp, ignore_errors=False, with_publications=False):
     """
     Parse the manifest file and collect the media package elements with all relevant information.
 
     :param mp: The media package
-    :type mp: MediaPackage
+    :type mp: Snapshot
     :param ignore_errors: Whether to ignore errors and recover the media package anyway
     :type ignore_errors: bool
-    :return: series id, tracks, catalogs, attachments
-    :rtype: str, list, list, list
+    :param with_publications: Whether to include publication elements
+    :type with_publications: bool
+    :return: The MediaPackage
+    :rtype: MediaPackage
     :raise MediaPackageError:
     """
 
@@ -54,10 +61,10 @@ def parse_manifest_from_filesystem(mp, ignore_errors=False):
     except Exception:
         raise MediaPackageError("Manifest of media package {} could not be parsed.".format(mp.id))
 
-    return __parse_manifest(manifest, mp.id, mp.path, ignore_errors)
+    return __parse_manifest(manifest, mp.id, mp.path, ignore_errors, with_publications)
 
 
-def __parse_manifest(manifest, mp_id, mp_path, ignore_errors=False):
+def __parse_manifest(manifest, mp_id, mp_path, ignore_errors=False, with_publications=False):
     """
     Parse the manifest and collect the media package elements with all relevant information.
 
@@ -69,8 +76,10 @@ def __parse_manifest(manifest, mp_id, mp_path, ignore_errors=False):
     :type mp_path: str or None
     :param ignore_errors: Whether to ignore errors and recover the media package anyway
     :type ignore_errors: bool
-    :return: series id, tracks, catalogs, attachments
-    :rtype: str, list, list, list
+    :param with_publications: Whether to include publication elements
+    :type with_publications: bool
+    :return: The MediaPackage
+    :rtype: MediaPackage
     :raise MediaPackageError:
     """
 
@@ -79,11 +88,28 @@ def __parse_manifest(manifest, mp_id, mp_path, ignore_errors=False):
     if series is not None:
         series_id = series.text
 
+    tracks, catalogs, attachments = _get_assets(manifest, mp_id, mp_path, ignore_errors)
+    publications = None
+
+    if with_publications:
+        publications = []
+        for publication in manifest.findall("./manifest:publications/", namespaces):
+            channel = publication.get("channel")
+            pub_tracks, pub_catalogs, pub_attachments = _get_assets(publication, mp_id, mp_path, ignore_errors, False)
+            publications.append(Publication(channel=channel, tracks=pub_tracks, attachments=pub_attachments,
+                                            catalogs=pub_catalogs))
+
+    return MediaPackage(id=mp_id, series_id=series_id, tracks=tracks, attachments=attachments, catalogs=catalogs,
+                        publications=publications)
+
+
+def _get_assets(target, mp_id, mp_path, ignore_errors, warn=True):
+
     elements = defaultdict(lambda: defaultdict(list))
 
     for element in ["media", "metadata", "attachments"]:
 
-        for sub_element in manifest.findall("./manifest:" + element+"/", namespaces):
+        for sub_element in target.findall("./manifest:" + element+"/", namespaces):
 
             subtype = sub_element.tag.split("}")[-1]
             sub_element_id = sub_element.get("id")
@@ -91,7 +117,7 @@ def __parse_manifest(manifest, mp_id, mp_path, ignore_errors=False):
             flavor = sub_element.get("type")
 
             mimetype_element = sub_element.find("manifest:mimetype", namespaces)
-            mimetype = mimetype_element.text if mimetype_element else None
+            mimetype = mimetype_element.text if (mimetype_element is not None) else None
 
             url = sub_element.find("manifest:url", namespaces).text
             file_extension = url.split(".")[-1]
@@ -113,17 +139,17 @@ def __parse_manifest(manifest, mp_id, mp_path, ignore_errors=False):
             if tag_elements:
                 tags = [element.text for element in tag_elements]
 
-            elements[element][subtype].append(Element(id=sub_element_id, flavor=flavor, mimetype=mimetype,
-                                                      filename=filename, path=path, tags=tags, url=url))
+            elements[element][subtype].append(Asset(id=sub_element_id, flavor=flavor, mimetype=mimetype,
+                                                    filename=filename, path=path, tags=tags, url=url))
 
-    tracks = __get_subtype_elements(elements, "media", "track", mp_id)
-    catalogs = __get_subtype_elements(elements, "metadata", "catalog", mp_id)
-    attachments = __get_subtype_elements(elements, "attachments", "attachment", mp_id)
+    tracks = __get_subtype_elements(elements, "media", "track", mp_id, warn)
+    catalogs = __get_subtype_elements(elements, "metadata", "catalog", mp_id, warn)
+    attachments = __get_subtype_elements(elements, "attachments", "attachment", mp_id, warn)
 
-    return series_id, tracks, catalogs, attachments
+    return tracks, catalogs, attachments
 
 
-def __get_subtype_elements(elements, element_type, subelement_type, mp_id):
+def __get_subtype_elements(elements, element_type, sub_element_type, mp_id, warn=True):
     """
     Get all elements of a specific type and subtype from elements of specific media package, print warnings if there are
     no such elements or if there are elements of a different subtype.
@@ -132,20 +158,21 @@ def __get_subtype_elements(elements, element_type, subelement_type, mp_id):
     :type elements: dict of dicts
     :param element_type: The type of elements to get
     :type element_type: str
-    :param subelement_type: The subtype of elements to get
-    :type subelement_type: str
+    :param sub_element_type: The subtype of elements to get
+    :type sub_element_type: str
     :param mp_id: The ID of the media package
     :type mp_id: str
     :return: All elements with specified type and subtype belonging to the specified media package
     :rtype: list
     """
 
-    if element_type not in elements.keys() or subelement_type not in elements[element_type].keys():
-        print("Warning: Media package {} has no {}s.".format(mp_id, subelement_type))
-        return []
+    if warn:
+        if element_type not in elements.keys() or sub_element_type not in elements[element_type].keys():
+            print("Warning: Media package {} has no {}s.".format(mp_id, sub_element_type))
+            return []
 
-    if len(elements[element_type].keys()) > 1:
-        print("Warning: Media package {} has {} elements that aren't {}s, these will not be recovered."
-              .format(mp_id, element_type, subelement_type))
+        if len(elements[element_type].keys()) > 1:
+            print("Warning: Media package {} has {} elements that aren't {}s, these will not be processed."
+                  .format(mp_id, element_type, sub_element_type))
 
-    return elements[element_type][subelement_type]
+    return elements[element_type][sub_element_type]

--- a/lib/rest_requests/file_requests.py
+++ b/lib/rest_requests/file_requests.py
@@ -17,3 +17,27 @@ def get_file_as_string(digest_login, url):
 
     response = get_request(url, digest_login, "file")
     return get_string_content(response)
+
+
+def get_video_file(digest_login, url, target_file):
+    """
+    Request a video and write it into a file.
+
+    :param url: The url to the file
+    :type url: str
+    :param digest_login: The login credentials for digest authentication
+    :type digest_login: DigestLogin
+    :param target_file: The file to write into
+    :type target_file: Path
+    :return: The file content
+    :rtype: str
+    :raise RequestError:
+    """
+
+    response = get_request(url, digest_login, "video", stream=True)
+
+    with open(target_file, 'wb') as f:
+        for chunk in response.iter_content(chunk_size=1024):
+            if chunk:
+                f.write(chunk)
+                f.flush()

--- a/lib/rest_requests/ingest_media_package.py
+++ b/lib/rest_requests/ingest_media_package.py
@@ -36,7 +36,7 @@ def add_attachment(base_url, digest_login, mp, attachment):
     :param mp: New media package.
     :type mp: str
     :param attachment: The attachment to be added.
-    :type attachment: Element
+    :type attachment: Asset
     :return: Augmented media package.
     :rtype: str
     :raise RequestError:
@@ -61,7 +61,7 @@ def add_attachment_with_url(base_url, digest_login, mp, attachment):
     :param mp: New media package.
     :type mp: str
     :param attachment: The attachment to be added.
-    :type attachment: Element
+    :type attachment: Asset
     :return: Augmented media package.
     :rtype: str
     :raise RequestError:
@@ -85,7 +85,7 @@ def add_catalog(base_url, digest_login, mp, catalog):
     :param mp: New media package.
     :type mp: str
     :param catalog: The catalog to be added.
-    :type catalog: Element
+    :type catalog: Asset
     :return: Augmented media package.
     :rtype: str
     :raise RequestError:
@@ -110,7 +110,7 @@ def add_catalog_with_url(base_url, digest_login, mp, catalog):
     :param mp: New media package.
     :type mp: str
     :param catalog: The catalog to be added.
-    :type catalog: Element
+    :type catalog: Asset
     :return: Augmented media package.
     :rtype: str
     :raise RequestError:
@@ -134,7 +134,7 @@ def add_track(base_url, digest_login, mp, track):
     :param mp: New media package.
     :type mp: str
     :param track: The catalog to be added.
-    :type track: Element
+    :type track: Asset
     :return: Augmented media package.
     :rtype: str
     :raise RequestError:
@@ -158,7 +158,7 @@ def add_track_with_url(base_url, digest_login, mp, track):
     :param mp: New media package.
     :type mp: str
     :param track: The track to be added.
-    :type track: Element
+    :type track: Asset
     :return: Augmented media package.
     :rtype: str
     :raise RequestError:

--- a/lib/rest_requests/request.py
+++ b/lib/rest_requests/request.py
@@ -10,7 +10,8 @@ from requests_toolbelt import MultipartEncoder
 from rest_requests.request_error import RequestError
 
 
-def get_request(url, digest_login, element_description, asset_type_description=None, asset_description=None):
+def get_request(url, digest_login, element_description, asset_type_description=None, asset_description=None,
+                stream=False):
     """
     Make a get request to the given url with the given digest login. If the request fails with an error or a status
     code != 200, a Request Error with the error message /status code and the given descriptions is thrown.
@@ -25,13 +26,15 @@ def get_request(url, digest_login, element_description, asset_type_description=N
     :type asset_type_description: str
     :param asset_description: Asset description in case of errors, e.g. 'Dublin Core catalogs', 'ACL'
     :type asset_description: str
+    :param stream: Whether to stream response
+    :type stream: bool
     :return: response
     :raise RequestError:
     """
 
     try:
         response = requests.get(url, auth=HTTPDigestAuth(digest_login.user, digest_login.password),
-                                headers={"X-Requested-Auth": "Digest"})
+                                headers={"X-Requested-Auth": "Digest"}, stream=stream)
     except Exception as e:
         raise RequestError.with_error(url, str(e), element_description, asset_type_description, asset_description)
 

--- a/lib/rest_requests/request.py
+++ b/lib/rest_requests/request.py
@@ -39,8 +39,8 @@ def get_request(url, digest_login, element_description, asset_type_description=N
         raise RequestError.with_error(url, str(e), element_description, asset_type_description, asset_description)
 
     if response.status_code < 200 or response.status_code > 299:
-        raise RequestError.with_statuscode(url, response.status_code, element_description, asset_type_description,
-                                           asset_description)
+        raise RequestError.with_status_code(url, str(response.status_code), element_description, asset_type_description,
+                                            asset_description)
     return response
 
 
@@ -77,8 +77,8 @@ def post_request(url, digest_login, element_description, asset_type_description=
         raise RequestError.with_error(url, str(e), element_description, asset_type_description, asset_description)
 
     if response.status_code < 200 or response.status_code > 299:
-        raise RequestError.with_statuscode(url, response.status_code, element_description, asset_type_description,
-                                           asset_description)
+        raise RequestError.with_status_code(url, str(response.status_code), element_description, asset_type_description,
+                                            asset_description)
     return response
 
 
@@ -126,6 +126,6 @@ def big_post_request(url, digest_login, element_description, asset_type_descript
 
     if response.status_code < 200 or response.status_code > 299:
         print(response.status_code)
-        raise RequestError.with_statuscode(url, response.status_code, element_description, asset_type_description,
-                                           asset_description)
+        raise RequestError.with_status_code(url, str(response.status_code), element_description, asset_type_description,
+                                            asset_description)
     return response

--- a/lib/rest_requests/request_error.py
+++ b/lib/rest_requests/request_error.py
@@ -16,11 +16,12 @@ class RequestError(Exception):
         :param error: error message
         :type error: str
         """
+        super(RequestError, self).__init__(error)
         self.error = error
 
     @classmethod
-    def with_statuscode(cls, url, status_code, element_description, asset_type_description=None,
-                        asset_description=None):
+    def with_status_code(cls, url, status_code, element_description, asset_type_description=None,
+                         asset_description=None):
         """
         Create a Request Error for a failed request to the given url with the given status code and an error message
         containing the given descriptions for the resource we were trying to get.

--- a/lib/rest_requests/stream_security_requests.py
+++ b/lib/rest_requests/stream_security_requests.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+from datetime import timedelta
+
+from rest_requests.get_response_content import get_string_content
+from rest_requests.request import get_request
+
+
+def sign_url(digest_login, server_url, url_to_sign):
+    """
+    Get a URL signed for 2 hours.
+
+    :param digest_login: The login credentials for digest auth
+    :type digest_login: DigestLogin
+    :param server_url: The server URL
+    :type server_url: str
+    :param url_to_sign: The url to be signed
+    :type url_to_sign: str
+    :return: The signed URL
+    :rtype: str
+    """
+
+    now = datetime.now()
+    two_hours = timedelta(hours=2)
+    two_hours_from_now = now + two_hours
+    two_hours_from_now_timestamp = int(two_hours_from_now.timestamp())
+
+    url = '{}/signing/sign?baseUrl={}&validUntil={}'.format(server_url, url_to_sign, two_hours_from_now_timestamp)
+    response = get_request(url, digest_login, "signed URL")
+    return get_string_content(response)

--- a/recover_backup/recover/find_media_packages.py
+++ b/recover_backup/recover/find_media_packages.py
@@ -5,7 +5,7 @@ import os
 
 from input_output.input import get_number
 
-MediaPackage = namedtuple('MediaPackage', ["id", "version", "path"])
+Snapshot = namedtuple('Snapshot', ["id", "version", "path"])
 
 
 def find_media_packages(backup_path, tenant, use_last_version, rsync_history_path, media_package_ids=None):
@@ -59,7 +59,7 @@ def find_media_packages(backup_path, tenant, use_last_version, rsync_history_pat
         version = __get_version(snapshots, mp_id, use_last_version)
         version_dir = os.path.join(mp_dir, str(version))
 
-        mps_to_recover.append(MediaPackage(id=mp_id, version=version, path=version_dir))
+        mps_to_recover.append(Snapshot(id=mp_id, version=version, path=version_dir))
 
     return mps_to_recover
 


### PR DESCRIPTION
With this script, you can export archived or published tracks of events in Opencast. You can select tracks by flavor, mime type and publication channel. This script works with stream security.

_This work was sponsored by SWITCH._