### PR TITLE
Use correct workflow start date in export-workflow-statistics-script

### DIFF
--- a/export-workflow-statistics/README.md
+++ b/export-workflow-statistics/README.md
@@ -8,7 +8,7 @@ This script works with multi-tenant systems.
 | Configuration Key      | Description                                                                       | Example                    |
 | :--------------------- | :-------------------------------------------------------------------------------- | :------------------------- |
 | `url`                  | The non-tenant-specific server URL                                                | https://opencast.com       |
-| `url_pattern`          | Pattern for the tenant-specific server URL, leave empty for single-tenant-systems | https://{}.opencast.com    |
+| `url_pattern`          | Pattern for the tenant-specific server URL, leave empty for single-tenant systems | https://{}.opencast.com    |
 | `digest_user`          | The user name of the digest user                                                  | opencast_system_account    |
 | `digest_pw`            | The password of the digest user                                                   | CHANGE_ME                  |
 | `workflow_definitions` | The ids of the workflow definitions to count                                      | ["ui-import", "api-import" |
@@ -18,7 +18,7 @@ This script works with multi-tenant systems.
 | `week_offset`          | The offset if the start date is not in the first calendar week                    | 1                          |
 | `export_dir`           | The path to the directory for the exported data                                   | "data"                     |
 
-* Both of these dates should be the first day of the week for the statistics to be accurate.
+&ast; Both of these dates should be the first day of the week for the statistics to be accurate.
 
 ### 2. Execute script
 
@@ -30,6 +30,8 @@ This script works with multi-tenant systems.
    
     `gnuplot plot.gp`
 
+![image](demo_plot.png)
+
 ### Optional: Plot tenant statistics
 
 If you have a multi-tenant system, you can also plot their statistics into a single graph. For this, adjust 
@@ -38,8 +40,6 @@ recording in the specified time frame will be plotted. The order of tenants is d
 (default: tenants with most processed recordings first).
 
 For gradual colors, uncomment the last line of `tenant_plot.gp`.
-
-![image](demo_plot.png)
 
 ## Requirements
 

--- a/export-workflow-statistics/config.py
+++ b/export-workflow-statistics/config.py
@@ -1,11 +1,12 @@
 # Configuration
 
-#Set this to your global admin node
-url = "https://stable.opencast.org"
-#If you have multiple tenants use something like
-#url_pattern = "https://{}.example.org"
-#otherwise, url_pattern should be the same as the url variable above
-url_pattern = "https://stable.opencast.org"
+# Set this to your global admin node
+url = "https://develop.opencast.org"
+
+# If you have multiple tenants use something like
+# url_pattern = "https://{}.example.org"
+# otherwise, url_pattern should be the same as the url variable above
+url_pattern = "https://develop.opencast.org"
 
 digest_user = "opencast_system_account"
 digest_pw = "CHANGE_ME"

--- a/export-workflow-statistics/main.py
+++ b/export-workflow-statistics/main.py
@@ -6,11 +6,11 @@ sys.path.append(os.path.join(os.path.abspath('..'), "lib"))
 import datetime
 import config
 import io
-from collections import defaultdict
+from collections import defaultdict, Counter
 from rest_requests.request_error import RequestError
 from args.digest_login import DigestLogin
 from rest_requests.basic_requests import get_tenants
-from rest_requests.workflow_requests import get_workflow_instances
+from rest_requests.workflow_requests import get_list_of_workflow_instances
 from pathlib import Path
 
 
@@ -22,86 +22,95 @@ def main():
     digest_login = DigestLogin(user=config.digest_user, password=config.digest_pw)
     tenants = get_tenants(config.url, digest_login)
 
-    weeks = __get_weeks(datetime.date.fromisoformat(config.start_date), datetime.date.fromisoformat(config.end_date))
-    count = defaultdict(int)
-    tenant_total_counts = dict()
+    start_date = datetime.date.fromisoformat(config.start_date)
+    end_date = datetime.date.fromisoformat(config.end_date)
+    delta = end_date - start_date
+    max_week = int(delta.days / 7) - 1
 
     tenant_dir = "tenant-statistics"
     Path(os.path.join(config.export_dir, tenant_dir)).mkdir(parents=True, exist_ok=True)
 
+    tenant_counts = dict()
     for tenant in tenants:
         if tenant not in config.exclude_tenants:
-
-            tenant_count = defaultdict(int)
             tenant_url = config.url_pattern.format(tenant) if config.url_pattern else config.url
 
-            for workflow_definition in config.workflow_definitions:
+            try:
+                tenant_count = __count_workflows_for_tenant(tenant_url, digest_login, config.workflow_definitions,
+                                                            start_date, end_date)
+                __export_tenant_statistics(config.export_dir, tenant_dir, tenant, tenant_count, max_week,
+                                           config.week_offset)
 
-                for i, week in enumerate(weeks):
+                tenant_counts[tenant] = tenant_count
+                print("{} done.".format(tenant))
+            except RequestError as e:
+                print("Workflows for tenant {} could not be counted: {}".format(tenant, str(e)))
 
-                    from_date = "{}T00:00:00Z".format(week[0])
-                    to_date = "{}T23:59:59Z".format(week[1])
+    __export_tenant_filenames(config.export_dir, tenant_dir, tenant_counts)
+    __export_aggregate_statistics(config.export_dir, max_week, config.week_offset, tenant_counts)
+    print("Done!\n")
 
-                    params = {"state": "SUCCEEDED", "fromdate": from_date, "todate": to_date,
-                              "workflowdefinition": workflow_definition, "startPage": "0",
-                              "count": "1", "compact": "True"}
-                    try:
-                        workflow_instances = get_workflow_instances(tenant_url, digest_login, params)
 
-                        count[i] += workflow_instances['totalCount']
-                        tenant_count[i] += workflow_instances['totalCount']
-                        print("{:30} {:>30} {:>3}".format(tenant, workflow_definition, i + config.week_offset + 1,
-                                                          count[i]))
-                    except RequestError as e:
-                        print("Workflows for tenant {}, workflow definition {} and dates {} to {} could not be "
-                              "requested: {}".format(tenant, workflow_definition, from_date, to_date, str(e)))
+def __export_tenant_filenames(export_dir, tenant_dir, tenant_counts):
+    # sum up total and then sort tenants by it
+    tenant_total_counts = {tenant: sum(tenant_count.values()) for tenant, tenant_count in tenant_counts.items()}
+    sorted_tenant_total_counts = dict(sorted(tenant_total_counts.items(), key=lambda item: item[1], reverse=True))
 
-            tenant_total_count = 0
-            with io.open(os.path.join(config.export_dir, tenant_dir, "{}-workflow-statistics.dat".format(tenant)),
-                         'w') as file:
-                for i, week in enumerate(weeks):
-                    file.write("{}   {}\n".format(i + config.week_offset + 1, tenant_count[i]))
-                    tenant_total_count += tenant_count[i]
-
-            tenant_total_counts[tenant] = tenant_total_count
-
-    sorted_tenant_total_counts = {k: v for k, v in sorted(tenant_total_counts.items(), key=lambda item: item[1],
-                                                          reverse=True)}
-
-    with io.open(os.path.join(config.export_dir, "filenames.txt"), 'w') as file:
-
+    with io.open(os.path.join(export_dir, "filenames.txt"), 'w') as file:
         for tenant in sorted_tenant_total_counts.keys():
             if sorted_tenant_total_counts[tenant] != 0:
                 print("{} {}".format(tenant, sorted_tenant_total_counts[tenant]))
                 file.write("{}/{}-workflow-statistics.dat\n".format(tenant_dir, tenant))
 
-    print("Done!\n")
 
-    with io.open(os.path.join(config.export_dir, "workflow-statistics.dat"), 'w') as file:
-        for i, week in enumerate(weeks):
-            file.write("{}   {}\n".format(i + config.week_offset + 1, count[i]))
+def __export_aggregate_statistics(export_dir, max_week, week_offset, tenant_counts):
+    # sum up numbers from each tenant
+    c = Counter()
+    for d in tenant_counts.values():
+        c.update(d)
+    aggregate_count = dict(c)
+
+    with io.open(os.path.join(export_dir, "workflow-statistics.dat"), 'w') as file:
+        for week in range(0, max_week):
+            file.write("{}   {}\n".format(week + week_offset + 1, aggregate_count[week]))
 
 
-def __get_weeks(start_date, end_date):
-    """
-    Get a tuple with first and last date of the week for all weeks between the given start and end dates. Both of these
-    should be the first day of a week, since we then count by offsets of 7.
+def __export_tenant_statistics(export_dir, tenant_dir, tenant, tenant_count, max_week, week_offset):
+    with io.open(os.path.join(export_dir, tenant_dir, "{}-workflow-statistics.dat".format(tenant)), 'w') as file:
+        for week in range(0, max_week):
+            file.write("{}   {}\n".format(week + week_offset + 1, tenant_count[week]))
 
-    :param start_date:
-    :type start_date: datetime.date
-    :param end_date:
-    :type end_date: datetime.date
-    :return: list of tuples
-    :rtype: list
-    """
-    weeks = []
-    end_of_week_delta = datetime.timedelta(days=6)
-    beginning_of_next_week_delta = datetime.timedelta(days=7)
 
-    while start_date <= end_date:
-        weeks.append((start_date, start_date + end_of_week_delta))
-        start_date += beginning_of_next_week_delta
-    return weeks
+def __count_workflows_for_tenant(tenant_url, digest_login, workflow_definitions, start_date, end_date):
+    tenant_count = defaultdict(int)
+
+    for workflow_definition in workflow_definitions:
+        page_offset = 0
+        limit = 100
+        get_workflows = True
+        while get_workflows:
+            workflow_instances = get_list_of_workflow_instances(tenant_url, digest_login,
+                                                                {"state": "SUCCEEDED",
+                                                                 "workflowdefinition": workflow_definition,
+                                                                 "startPage": str(page_offset),
+                                                                 "count": str(limit), "compact": "False"})
+
+            for workflow_instance in workflow_instances:
+                operations = workflow_instance["operations"]["operation"]
+
+                if operations:
+                    timestamp = operations[0]["started"]  # start of first operation
+                    workflow_start_date = datetime.date.fromtimestamp(timestamp/1000)  # milliseconds to seconds
+
+                    if start_date <= workflow_start_date <= end_date:
+                        delta = workflow_start_date - start_date
+                        week = int(delta.days / 7)
+                        tenant_count[week] += 1
+            get_workflows = len(workflow_instances) == limit
+            page_offset += 1
+            print("        {} workflow instances counted.".format(page_offset * limit + len(workflow_instances)))
+        print("    {} done.".format(workflow_definition))
+    return tenant_count
 
 
 if __name__ == '__main__':

--- a/export-workflow-statistics/main.py
+++ b/export-workflow-statistics/main.py
@@ -33,6 +33,7 @@ def main():
     tenant_counts = dict()
     for tenant in tenants:
         if tenant not in config.exclude_tenants:
+            print("{}".format(tenant))
             tenant_url = config.url_pattern.format(tenant) if config.url_pattern else config.url
 
             try:
@@ -42,13 +43,12 @@ def main():
                                            config.week_offset)
 
                 tenant_counts[tenant] = tenant_count
-                print("{} done.".format(tenant))
             except RequestError as e:
                 print("Workflows for tenant {} could not be counted: {}".format(tenant, str(e)))
 
     __export_tenant_filenames(config.export_dir, tenant_dir, tenant_counts)
     __export_aggregate_statistics(config.export_dir, max_week, config.week_offset, tenant_counts)
-    print("Done!\n")
+    print("Done\n")
 
 
 def __export_tenant_filenames(export_dir, tenant_dir, tenant_counts):
@@ -59,7 +59,6 @@ def __export_tenant_filenames(export_dir, tenant_dir, tenant_counts):
     with io.open(os.path.join(export_dir, "filenames.txt"), 'w') as file:
         for tenant in sorted_tenant_total_counts.keys():
             if sorted_tenant_total_counts[tenant] != 0:
-                print("{} {}".format(tenant, sorted_tenant_total_counts[tenant]))
                 file.write("{}/{}-workflow-statistics.dat\n".format(tenant_dir, tenant))
 
 
@@ -85,6 +84,7 @@ def __count_workflows_for_tenant(tenant_url, digest_login, workflow_definitions,
     tenant_count = defaultdict(int)
 
     for workflow_definition in workflow_definitions:
+        print("    {}".format(workflow_definition))
         page_offset = 0
         limit = 100
         get_workflows = True
@@ -106,10 +106,9 @@ def __count_workflows_for_tenant(tenant_url, digest_login, workflow_definitions,
                         delta = workflow_start_date - start_date
                         week = int(delta.days / 7)
                         tenant_count[week] += 1
+            print("        {:3} workflow instances".format(page_offset * limit + len(workflow_instances)))
             get_workflows = len(workflow_instances) == limit
             page_offset += 1
-            print("        {} workflow instances counted.".format(page_offset * limit + len(workflow_instances)))
-        print("    {} done.".format(workflow_definition))
     return tenant_count
 
 

--- a/lib/rest_requests/workflow_requests.py
+++ b/lib/rest_requests/workflow_requests.py
@@ -50,3 +50,28 @@ def get_workflow_instances(base_url, digest_login, params):
 
     response = get_request(url, digest_login, "workflow instances")
     return get_json_content(response)["workflows"]
+
+
+def get_list_of_workflow_instances(base_url, digest_login, params):
+    """
+    Wrapper for get_workflow_instances() to get only a list of workflow instances, not the additional information.
+
+    :param base_url: The URL for the request
+    :type base_url: str
+    :param digest_login: The login credentials for digest authentication
+    :type digest_login: DigestLogin
+    :param params: Additional parameters
+    :type params: dict
+    :return: list of workflow instances
+    :rtype: list
+    """
+
+    workflows = get_workflow_instances(base_url, digest_login, params)
+
+    if "workflow" not in workflows:
+        return []
+
+    workflows = workflows["workflow"]
+    if not isinstance(workflows, list):  # happens if there's only one
+        workflows = [workflows]
+    return workflows


### PR DESCRIPTION
The filters `fromdate` and `todate` do not filter by workflow start date, as the rest docs suggest, but by the bibliographical start date from the event metadata, which can be edited and is thus not reliable.
The workflow instances themselves do not contain a start date. One can get the job to the workflow instance, which contains the start date, but that would mean one additional request to the service registry per workflow instance, which can get pretty slow.
So instead, I'm using the start date of the first workflow operation now. The difference to the job start date should be minimal and doesn't really matter for the time frames we are interested in.
The script is still slower than before, since we now have to parse the actual instances instead of using request filters and the `totalCount`, but that can't be helped...