### PR TITLE
Export Search Videos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 venv
 __pycache__
 .idea
+*.pyc

--- a/export-videos/README.md
+++ b/export-videos/README.md
@@ -8,18 +8,23 @@ With this script, you can export archived or published video tracks from Opencas
 
 First you need to configure the script in `config.py`:
 
-| Configuration Key     | Description                                                              | Example                     |
-| :-------------------- | :----------------------------------------------------------------------- | :-------------------------- |
-| `url`                 | The (tenant-specific) server URL                                         | https://tenant.opencast.com |
-| `digest_user`         | The user name of the digest user                                         | opencast_system_account     |
-| `digest_pw`           | The password of the digest user                                          | CHANGE_ME                   |
-| `stream_security`     | Whether to sign the URLs before downloading                              | False                       |
-| `target_directory`    | The path to the directory for the exported videos                        | /home/user/Desktop/videos   |
-| `export_archived`     | Whether to export archived tracks                                        | True                        |
-| `export_publications` | The publication channel(s) for which published tracks should be exported | \["engage-player"\]         |
-| `export_mimetypes`    | The type(s) of video to export (empty: all types)                        | \["video/mp4"]\             |
-| `export_flavors`      | The flavor(s) to export (empty: all flavors)                             | \["delivery/*"\]            |
-| `create_series_dirs`  | Whether to create a directory for each series when using the `-s`option  | False                       |
+| Configuration Key     | Description                                                                 | Example                                  |
+| :-------------------- | :-------------------------------------------------------------------------- | :--------------------------------------- |
+| `admin_url`           | The (tenant-specific) admin URL                                             | https://tenant.admin.opencast.com        |
+| `presentation_url`    | The (tenant-specific) presentation URL if it's different from the admin URL | https://tenant.presentation.opencast.com |
+| `digest_user`         | The user name of the digest user                                            | opencast_system_account                  |
+| `digest_pw`           | The password of the digest user                                             | CHANGE_ME                                |
+| `stream_security`     | Whether to sign the URLs before downloading                                 | False                                    |
+| `target_directory`    | The path to the directory for the exported videos                           | /home/user/Desktop/videos                |
+| `export_archived`     | Whether to export archived tracks                                           | True                                     |
+| `export_search`       | Whether to export tracks from the search service\*                          | True                                     |
+| `export_publications` | The publication channel(s) for which published tracks should be exported\*  | \["engage-player"\]                      |
+| `export_mimetypes`    | The type(s) of video to export (empty: all types)                           | \["video/mp4"]\                          |
+| `export_flavors`      | The flavor(s) to export (empty: all flavors)                                | \["delivery/*"\]                         |
+| `create_series_dirs`  | Whether to create a directory for each series when using the `-s`option     | False                                    |
+
+&ast; Use the search option to export tracks used by the Engage Player, since the engage-player publication doesn't actually
+contain the tracks.
 
 ### Usage
 

--- a/export-videos/config.py
+++ b/export-videos/config.py
@@ -1,6 +1,7 @@
 # Configuration
 
-url = "https://tenant.opencast.com"  # CHANGE ME
+admin_url = "http://develop.opencast.org"  # CHANGE ME
+# presentation_url =  # defaults to admin url, configure for separate presentation node
 target_directory = "/home/user/Desktop/videos"  # CHANGE ME
 create_series_dirs = False
 digest_user = "opencast_system_account"
@@ -9,6 +10,7 @@ stream_security = False
 
 # export settings
 export_archived = True
-export_publications = ["engage-player"]
+export_publications = ["internal"]
+export_search = True
 export_mimetypes = ["video/mp4"]
 export_flavors = []

--- a/export-videos/export_videos.py
+++ b/export-videos/export_videos.py
@@ -5,13 +5,15 @@ from rest_requests.file_requests import get_video_file
 from rest_requests.stream_security_requests import sign_url
 
 
-def export_videos(mp, mp_dir, server_url, digest_login, export_archived, export_publications, export_mimetypes,
-                  export_flavors, sign=False):
+def export_videos(archive_mp, search_mp, mp_dir, server_url, digest_login, export_archived, export_publications,
+                  export_mimetypes, export_flavors, sign=False):
     """
     Request the tracks of the media package that meet the criteria and export them to video files.
 
-    :param mp: The media package whose tracks should be exported
-    :type mp: MediaPackage
+    :param archive_mp: The media package whose tracks should be exported
+    :type archive_mp: MediaPackage
+    :param search_mp: The search media package whose tracks should be exported (optional)
+    :type search_mp: MediaPackage
     :param mp_dir: The directory for the media package
     :type mp_dir: Path
     :param export_archived: Whether to export archived tracks
@@ -33,28 +35,57 @@ def export_videos(mp, mp_dir, server_url, digest_login, export_archived, export_
     # check archived tracks
     if export_archived:
         target_dir = os.path.join(mp_dir, 'archived')
-
-        for track in mp.tracks:
-            if __check_track(track, export_mimetypes, export_flavors):
-                try:
-                    __export_track(target_dir, track, server_url, digest_login, sign)
-                except Exception as e:
-                    print("Archived Track {} of media package {} could not be exported: {}"
-                          .format(track.id, mp.id, str(e)))
+        __export_tracks(archive_mp.id, archive_mp.tracks, target_dir, server_url, digest_login, sign, export_mimetypes,
+                        export_flavors)
 
     # check published tracks
     if export_publications:
-        for publication in mp.publications:
+        for publication in archive_mp.publications:
             if publication.channel in export_publications:
                 target_dir = os.path.join(mp_dir, publication.channel)
+                __export_tracks(archive_mp.id, publication.tracks, target_dir, server_url, digest_login, sign,
+                                export_mimetypes, export_flavors, publication.channel)
 
-                for track in publication.tracks:
-                    if __check_track(track, export_mimetypes, export_flavors):
-                        try:
-                            __export_track(target_dir, track, server_url, digest_login, sign)
-                        except Exception as e:
-                            print("Track {} of publication {} of media package {} could not be exported: {}"
-                                  .format(track.id, publication.channel, mp.id, str(e)))
+    if search_mp:
+        target_dir = os.path.join(mp_dir, 'search')
+        __export_tracks(search_mp.id, search_mp.tracks, target_dir, server_url, digest_login, sign, export_mimetypes,
+                        export_flavors, 'search')
+
+
+def __export_tracks(mp_id, tracks, target_dir, server_url, digest_login, sign, export_mimetypes, export_flavors,
+                    publication_channel=None):
+    """
+    Export tracks.
+    :param mp_id: Media package id
+    :type mp_id: str
+    :param tracks: The tracks
+    :type tracks: list
+    :param target_dir: The target directory
+    :type target_dir: Path
+    :param server_url: The server URL
+    :type server_url: str
+    :param digest_login: The login credentials for digest authentication
+    :type digest_login: DigestLogin
+    :param sign: Whether to sign the URL first
+    :type sign: bool
+    :param export_mimetypes: The mimetypes to be exported
+    :type export_mimetypes: list
+    :param export_flavors: The flavors to be exported
+    :type export_flavors: list
+    :param publication_channel: The publication channel (for logging only)
+    :type publication_channel: str
+    """
+
+    for track in tracks:
+        if __check_track(track, export_mimetypes, export_flavors):
+            try:
+                __export_track(target_dir, track, server_url, digest_login, sign)
+            except Exception as e:
+                if publication_channel:
+                    print("Track {} of publication '{}' of media package {} could not be exported: {}"
+                          .format(track.id, publication_channel, mp_id, str(e)))
+                else:
+                    print("Track {} of media package {} could not be exported: {}".format(track.id, mp_id, str(e)))
 
 
 def __check_track(track, export_mimetypes, export_flavors):

--- a/lib/rest_requests/search_requests.py
+++ b/lib/rest_requests/search_requests.py
@@ -1,0 +1,26 @@
+from rest_requests.get_response_content import get_json_content
+from rest_requests.request import get_request
+
+
+def get_episode_from_search(base_url, digest_login, event_id):
+    """
+    Get episode from search as json.
+
+    :param base_url: The base URL for the request
+    :type base_url: str
+    :param digest_login: The login credentials for digest authentication
+    :type digest_login: DigestLogin
+    :param event_id: The event id
+    :type event_id: str
+    :return: episode as json or None
+    :rtype: episode as json or None
+    :raise RequestError:
+    """
+
+    url = '{}/search/episode.json?id={}'.format(base_url, event_id)
+
+    response = get_request(url, digest_login, "search episode")
+    search_results = get_json_content(response)["search-results"]
+    if "result" in search_results:
+        return search_results["result"]
+    return None


### PR DESCRIPTION
This extends the export script to export videos from the search service since the engage-player publication doesn't actually contain the tracks.

*This work was sponsored by the University of Jena.*