### PR TITLE
Fix README of start-workflow-from-archive

### DIFF
--- a/start-workflow-from-archive/README.md
+++ b/start-workflow-from-archive/README.md
@@ -36,7 +36,7 @@ An additional script is created to start workflows on a list of media packages.
 
 Usage:
 ```
-$ sh start-multiple-workflows.sh --help
+$ bash start-multiple-workflows.sh --help
 usage: start-multiple-workflows.sh -w WORKFLOW [-W PROPERTIES] [-o OPENCAST] [-u USER] [-p PASSWORD] [-h]
 
 required arguments:
@@ -55,6 +55,6 @@ optional arguments:
 
 Example:
 ```
-cat mediapackages.txt | sh start-multiple-workflows.sh -o https://develop.opencast.org -w republish-metadata \
+cat mediapackages.txt | bash start-multiple-workflows.sh -o https://develop.opencast.org -w republish-metadata \
                                                        -W publishToEngage=false -W publishToOaiPmh=true
 ```


### PR DESCRIPTION
You need bash instead of sh to execute start-multiple-workflows.sh.