### PR TITLE
Add script to start workflows for multiple events of different tenants

### DIFF
--- a/lib/rest_requests/workflow_requests.py
+++ b/lib/rest_requests/workflow_requests.py
@@ -1,3 +1,5 @@
+import json
+
 from rest_requests.get_response_content import get_json_content
 from rest_requests.request import post_request, get_request
 
@@ -23,6 +25,33 @@ def start_workflow(base_url, digest_login, workflow_definition, media_package):
     data = {'definition': workflow_definition, 'mediapackage': media_package}
 
     post_request(url, digest_login, element_description="/workflow/start", data=data)
+
+
+def start_task(base_url, digest_login, workflow_definition, event_id):
+    """
+        Start a workflow on a media package.
+
+    :param base_url: The URL for the request
+    :type base_url: str
+    :param digest_login: The login credentials for digest authentication
+    :type digest_login: DigestLogin
+    :param workflow_definition: The workflow definition
+    :type workflow_definition: str
+    :param event_id: the event id
+    :type event_id: str
+    :return: The workflow instance
+    :rtype: str
+    :raise RequestError:
+    """
+
+    url = '{}/admin-ng/tasks/new'.format(base_url)
+    # hardcode workflow definition and ingest start date since I don't think it's actually relevant
+    metadata = {'workflow': workflow_definition,
+                'configuration': {'{}'.format(event_id): {"workflowDefinitionId": "fast",
+                                                          "ingest_start_date": "20210607T020914Z"}}}
+    data = {'metadata': json.dumps(metadata)}
+
+    post_request(url, digest_login, element_description="/admin-ng/tasks/new", data=data)
 
 
 def get_workflow_instances(base_url, digest_login, params):

--- a/start-workflow-from-archive-multitenancy/README.md
+++ b/start-workflow-from-archive-multitenancy/README.md
@@ -1,0 +1,42 @@
+# Script to start a workflow for multiple events belonging to different tenants
+
+With this script, you can start workflows for multiple events belonging to different tenants, if the tenant-specific 
+Admin URLs follow a pattern. To use this, you need to put the event ids into files named after the tenant they belong 
+to, one id per line.
+Currently, this script doesn't support workflow parameters. In contrast to start-workflow-from-archive, this script uses
+/admin-ng/tasks/new to start the workflow, not workflow/start.
+
+## How to Use
+
+### Configuration
+
+First you need to configure the script in `config.py`:
+
+| Configuration Key | Description                                                 | Default/Example         |
+| :---------------- | :---------------------------------------------------------- | :---------------------- |
+| `url_pattern`      | The pattern for the tenant-specific URLs to the admin node  | https://{}.opencast.com |
+| `digest_user`     | The user name of the digest user                            | opencast_system_account |
+| `digest_pw`       | The password of the digest user                             | CHANGE_ME               |
+
+### Usage
+
+The script can be called with the following parameters:
+
+`main.py -w WORKFLOW_DEFINITION -d DIRECTORY`
+
+| Short Option | Long Option   | Description                                       |
+| :----------: | :------------ | :------------------------------------------------ |
+| `-w`         | `--workflow`  | The workflow to start                             |
+| `-d`         | `--directory` | The path to the directory with the event id files |
+
+#### Usage example
+
+`main.py -w republish-metadata -d /home/user/Desktop/events`
+
+## Requirements
+
+This script was written for Python 3.8. You can install the necessary packages with
+
+`pip install -r requirements.txt`
+
+Additionally, this script uses modules contained in the _lib_ directory.

--- a/start-workflow-from-archive-multitenancy/config.py
+++ b/start-workflow-from-archive-multitenancy/config.py
@@ -1,0 +1,3 @@
+url_pattern = "https://{}.opencast.com"  # CHANGE ME
+digest_user = "opencast_system_account"
+digest_pw = "CHANGE_ME"  # CHANGE ME

--- a/start-workflow-from-archive-multitenancy/main.py
+++ b/start-workflow-from-archive-multitenancy/main.py
@@ -1,0 +1,55 @@
+import os
+import sys
+import io
+import config
+
+sys.path.append(os.path.join(os.path.abspath('..'), "lib"))
+
+from args.digest_login import DigestLogin
+from args.args_error import args_error
+from args.args_parser import get_args_parser
+from rest_requests.request_error import RequestError
+from rest_requests.workflow_requests import start_task
+
+
+def parse_args():
+    """
+    Parse the arguments and check them for correctness
+
+    :return: workflow definition, directory path
+    :rtype: str, str
+    """
+    parser, optional_args, required_args = get_args_parser()
+    required_args.add_argument("-w", "--workflow", type=str, help="The workflow to start")
+    required_args.add_argument("-d", "--dir", type=str, help="The path to the directory containing the event id files")
+    args = parser.parse_args()
+
+    if not os.path.isdir(args.dir):
+        args_error(parser, "Provided directory doesn't exist!")
+
+    return args.workflow, args.dir
+
+
+def main():
+    digest_login = DigestLogin(user=config.digest_user, password=config.digest_pw)
+    workflow_definition, directory = parse_args()
+
+    dir_name, sub_dirs, files = next(os.walk(directory))
+    for file in files:
+        tenant = os.path.splitext(file)[0]
+        server_url = config.url_pattern.format(tenant)
+        file_path = os.path.join(directory, file)
+        print("Starting with tenant {}".format(tenant))
+
+        with io.open(file_path, 'r', newline='\n', encoding='utf8') as f:
+            for event_id in f:
+                event_id = event_id.rstrip('\n')
+                try:
+                    start_task(server_url, digest_login, workflow_definition, event_id)
+                    print("Workflow started for event {}.".format(event_id))
+                except RequestError as e:
+                    print("Workflow couldn't be started for event: {} {}".format(event_id, e.error))
+
+
+if __name__ == '__main__':
+    main()

--- a/start-workflow-from-archive-multitenancy/requirements.txt
+++ b/start-workflow-from-archive-multitenancy/requirements.txt
@@ -1,0 +1,7 @@
+certifi==2021.5.30
+chardet==4.0.0
+idna==2.10
+pkg-resources==0.0.0
+requests==2.25.1
+requests-toolbelt==0.9.1
+urllib3==1.26.5


### PR DESCRIPTION
... since the existing script does not support multi tenancy. To use this, you need to put the event ids into files named after the tenant they belong to, one id per line.

It's pretty simple right now (e.g. doesn't support workflow parameters yet because I didn't need it), but could be easily extended.
In contrast to start-workflow-from-archive, this uses /admin-ng/tasks/new instead of workflow/start because I had some issues with Bad Gateway with the latter that I just couldn't find.