### PR TITLE
Extend export videos script

### DIFF
--- a/export-videos/README.md
+++ b/export-videos/README.md
@@ -30,7 +30,8 @@ First you need to configure the script in `config.py`:
 actually contain the tracks. For this to work you need to configure the presentation url if you have a separate
 presentation node.
 
-&ast;&ast; In case of duplicates, numbers are appended.
+&ast;&ast; In cases where the name cannot be expected to be unique (= is not an id) and the file or directory already
+exists, a number will be appended. This will result in duplicates if you run the script twice with the same parameters.
 
 ### Usage
 

--- a/export-videos/README.md
+++ b/export-videos/README.md
@@ -22,12 +22,15 @@ First you need to configure the script in `config.py`:
 | `export_flavors`      | The flavor(s) of videos to export (empty: videos of all flavors)            | \["delivery/*"\]                         |
 | `export_catalogs`     | The flavor(s) of catalogs to export (empty: no catalogs)                    | \["smil/cutting", "dublincore/*"\]       |
 | `target_directory`    | The path to the directory for the exported videos                           | /home/user/Desktop/videos                |
-| `create_series_dirs`  | Whether to create a directory for each series when using the `-s`option     | False                                    |
-| `original_filenames`  | Whether to keep the original filenames (otherwise track id is used)         | False                                    |
+| `create_series_dirs`  | Whether to create a directory for each series when using the `-s` option    | False                                    |
+| `original_filenames`  | Whether to keep the original filenames instead of using the element ids\*\* | False                                    |
+| `title_folders`       | Whether to use event/series titles instead of ids as folder names\*\*       | False                                    |
 
 &ast; Use the search option to export tracks used by the Engage Player, since the engage-player publication doesn't
 actually contain the tracks. For this to work you need to configure the presentation url if you have a separate
 presentation node.
+
+&ast;&ast; In case of duplicates, numbers are appended.
 
 ### Usage
 

--- a/export-videos/config.py
+++ b/export-videos/config.py
@@ -19,3 +19,4 @@ export_catalogs = ["smil/cutting", "dublincore/*"]
 target_directory = "/home/user/Desktop/videos"  # CHANGE ME
 create_series_dirs = False
 original_filenames = False
+title_folders = False

--- a/export-videos/export.py
+++ b/export-videos/export.py
@@ -1,7 +1,8 @@
 import os
 
 from data_handling.flavor_matcher import matches_flavor
-from rest_requests.file_requests import export_video_file, make_filename_unique, export_text_file
+from input_output.unique_names import make_filename_unique
+from rest_requests.file_requests import export_video_file, export_text_file
 from rest_requests.stream_security_requests import sign_url
 
 

--- a/export-videos/main.py
+++ b/export-videos/main.py
@@ -43,6 +43,7 @@ def main():
         event_ids = [get_id(event) for event in events]
 
     print("Starting export process.")
+    series_dirs = {}
     for event_id in event_ids:
         try:
             print("Exporting media package {}".format(event_id))
@@ -61,10 +62,17 @@ def main():
 
             # build target directory path
             target_dir = config.target_directory
-
             if config.create_series_dirs and archive_mp.series_id:
-                series_dir = make_dirname_unique(target_dir, archive_mp.series_title) if config.title_folders \
-                    else archive_mp.series_id
+                if config.title_folders:
+                    # if we use series titles as folder names, we need to remember the directory so we don't create a
+                    # new one for the same series
+                    if archive_mp.series_id in series_dirs:
+                        series_dir = series_dirs[archive_mp.series_id]
+                    else:
+                        series_dir = make_dirname_unique(target_dir, archive_mp.series_title)
+                        series_dirs[archive_mp.series_id] = series_dir
+                else:
+                    series_dir = archive_mp.series_id
                 target_dir = os.path.join(target_dir, series_dir)
 
             mp_dir = make_dirname_unique(target_dir, archive_mp.title) if config.title_folders else archive_mp.id

--- a/export-videos/main.py
+++ b/export-videos/main.py
@@ -4,6 +4,7 @@ import sys
 sys.path.append(os.path.join(os.path.abspath('..'), "lib"))
 
 import config
+from input_output.unique_names import make_dirname_unique
 from args.digest_login import DigestLogin
 from data_handling.elements import get_id
 from data_handling.parse_manifest import parse_manifest_from_endpoint
@@ -58,19 +59,24 @@ def main():
             archive_mp_xml = get_media_package(config.admin_url, digest_login, event_id)
             archive_mp = parse_manifest_from_endpoint(archive_mp_xml, event_id, False, True)
 
-            # set target directory
+            # build target directory path
+            target_dir = config.target_directory
+
             if config.create_series_dirs and archive_mp.series_id:
-                mp_dir = os.path.join(config.target_directory, archive_mp.series_id, archive_mp.id)
-            else:
-                mp_dir = os.path.join(config.target_directory, archive_mp.id)
+                series_dir = make_dirname_unique(target_dir, archive_mp.series_title) if config.title_folders \
+                    else archive_mp.series_id
+                target_dir = os.path.join(target_dir, series_dir)
+
+            mp_dir = make_dirname_unique(target_dir, archive_mp.title) if config.title_folders else archive_mp.id
+            target_dir = os.path.join(target_dir, mp_dir)
 
             # export
-            export_videos(archive_mp, search_mp, mp_dir, config.admin_url, digest_login, config.export_archived,
+            export_videos(archive_mp, search_mp, target_dir, config.admin_url, digest_login, config.export_archived,
                           config.export_publications, config.export_mimetypes, config.export_flavors,
                           config.stream_security, config.original_filenames)
 
             if config.export_catalogs:
-                export_catalogs(archive_mp, mp_dir, config.admin_url, digest_login, config.export_catalogs,
+                export_catalogs(archive_mp, target_dir, config.admin_url, digest_login, config.export_catalogs,
                                 config.stream_security, config.original_filenames)
 
         except Exception as e:

--- a/import-to-other-tenant/main.py
+++ b/import-to-other-tenant/main.py
@@ -60,9 +60,9 @@ def main():
         try:
             mp = get_media_package(config.source_url, digest_login, event_id)
 
-            series_id, tracks, catalogs, attachments = parse_manifest_from_endpoint(mp, event_id, False)
+            mp = parse_manifest_from_endpoint(mp, event_id, False)
 
-            workflow = import_mp(series_id, tracks, catalogs, attachments, config.target_url, digest_login,
+            workflow = import_mp(mp.series_id, mp.tracks, mp.catalogs, mp.attachments, config.target_url, digest_login,
                                  config.workflow_id, config.workflow_config, False, True)
 
             print("Imported media package {} (new id: {}) and started workflow {} with id {}.".

--- a/lib/input_output/unique_names.py
+++ b/lib/input_output/unique_names.py
@@ -14,7 +14,7 @@ def make_filename_unique(base_dir, file_name, file_extension):
     :return: unique filename
     :rtype: str
     """
-    counter = 1
+    counter = 2
     original_file_name = file_name
     path = os.path.join(base_dir, '{}.{}'.format(file_name, file_extension))
     while os.path.exists(path):
@@ -35,7 +35,7 @@ def make_dirname_unique(base_dir, dir_name):
     :return: unique directory name
     :rtype: str
     """
-    counter = 1
+    counter = 2
     original_dir_name = dir_name
     path = os.path.join(base_dir, dir_name)
     while os.path.exists(path):

--- a/lib/input_output/unique_names.py
+++ b/lib/input_output/unique_names.py
@@ -1,0 +1,45 @@
+import os
+
+
+def make_filename_unique(base_dir, file_name, file_extension):
+    """
+    Make sure filename is unique by checking if the file exists and appending a number if it does.
+
+    :param base_dir: path to file
+    :type base_dir: Path
+    :param file_name: file name
+    :type file_name: str
+    :param file_extension: file extension
+    :type file_extension: str
+    :return: unique filename
+    :rtype: str
+    """
+    counter = 1
+    original_file_name = file_name
+    path = os.path.join(base_dir, '{}.{}'.format(file_name, file_extension))
+    while os.path.exists(path):
+        file_name = original_file_name + "(" + str(counter) + ")"
+        path = os.path.join(base_dir, '{}.{}'.format(file_name, file_extension))
+        counter += 1
+    return file_name
+
+
+def make_dirname_unique(base_dir, dir_name):
+    """
+    Make sure directory name is unique by checking if the directory exists and appending a number if it does.
+
+    :param base_dir: path to directory
+    :type base_dir: Path
+    :param dir_name: directory name
+    :type dir_name: str
+    :return: unique directory name
+    :rtype: str
+    """
+    counter = 1
+    original_dir_name = dir_name
+    path = os.path.join(base_dir, dir_name)
+    while os.path.exists(path):
+        dir_name = original_dir_name + "(" + str(counter) + ")"
+        path = os.path.join(base_dir, dir_name)
+        counter += 1
+    return dir_name

--- a/lib/rest_requests/file_requests.py
+++ b/lib/rest_requests/file_requests.py
@@ -1,5 +1,3 @@
-import os
-
 from rest_requests.get_response_content import get_string_content
 from rest_requests.request import get_request
 
@@ -60,14 +58,3 @@ def export_video_file(digest_login, url, target_file):
             if chunk:
                 f.write(chunk)
                 f.flush()
-
-
-def make_filename_unique(directory, filename, file_extension):
-    counter = 1
-    original_filename = filename
-    path = os.path.join(directory, '{}.{}'.format(filename, file_extension))
-    while os.path.exists(path):
-        filename = original_filename + "(" + str(counter) + ")"
-        path = os.path.join(directory, '{}.{}'.format(filename, file_extension))
-        counter += 1
-    return filename

--- a/recover_backup/main.py
+++ b/recover_backup/main.py
@@ -64,10 +64,10 @@ def main():
         try:
 
             # parse manifest
-            series_id, tracks, catalogs, attachments = parse_manifest_from_filesystem(mp, ignore_errors)
+            mp = parse_manifest_from_filesystem(mp, ignore_errors)
 
-            workflow = import_mp(series_id, tracks, catalogs, attachments, base_url, digest_login, workflow_id, {},
-                                 ignore_errors)
+            workflow = import_mp(mp.series_id, mp.tracks, mp.catalogs, mp.attachments, base_url, digest_login,
+                                 workflow_id, {}, ignore_errors)
 
             print("Recovered media package {} (new id: {}) and started workflow {} with id {}.".
                   format(mp.id, workflow.mp_id, workflow.template, workflow.id))


### PR DESCRIPTION
This extends the export-videos script so we can use series or event titles as folder names instead of their ids. If the folder already exists, a number will be appended.

Attention: This means that when you run the script with the same parameters multiple times, you will have data duplication!