### PR TITLE
Removed travis build tag readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,6 @@
 Helper Scripts For Opencast
 ===========================
 
-[![Build Status
-](https://travis-ci.org/opencast/helper-scripts.svg?branch=master)
-](https://travis-ci.org/opencast/helper-scripts)
-
 This repository contains several small helper scripts to automate certain tasks
 mostly for *testing* purposes. Please note that these scripts are not part of
 Opencast and may be doing weird and/or insecure things. Please read the scripts


### PR DESCRIPTION
The Helper Scripts are a collection of different scripts for Opencast and each one is independent. Thus, building with travis will not work