### PR TITLE
Fake HLS Streaming Source

### DIFF
--- a/fake-hls/fake-hls.sh
+++ b/fake-hls/fake-hls.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+#Note: this temp dir grows without bounds.  Make sure it lives somewhere that can handle that...
+temp=`mktemp -d`
+#Create the docker container
+nginx=`docker run --rm -d -v $temp:/tmp -v \`pwd\`/nginx.conf:/etc/nginx/nginx.conf:ro -p 8888:80 nginx:stable`
+#Then start the stream, after making sure everyone can read and execute the temp directory
+cd $temp
+chmod -R a+rx $temp
+ffmpeg -hide_banner \
+  -re -f lavfi -i "
+    testsrc2=size=1920x540:rate=25,
+    drawbox=x=0:y=0:w=700:h=50:c=black@.6:t=fill,
+    drawtext=x=  5:y=5:fontsize=54:fontcolor=white:text='%{pts\:gmtime\:$(date +%s)\:%Y-%m-%d}',
+    drawtext=x=345:y=5:fontsize=54:fontcolor=white:timecode='$(date -u '+%H\:%M\:%S')\:00':rate=25:tc24hmax=1,
+    setparams=field_mode=prog:range=tv:color_primaries=bt709:color_trc=bt709:colorspace=bt709,
+    format=yuv420p" \
+  -re -f lavfi -i "
+    sine=f=1000:r=48000:samples_per_frame='st(0,mod(n,5)); 1602-not(not(eq(ld(0),1)+eq(ld(0),3)))'" \
+  -shortest \
+  -fflags genpts \
+  \
+  -filter_complex "
+    [0:v]drawtext=x=(w-text_w)-5:y=5:fontsize=54:fontcolor=white:text='1920x540':box=1:boxcolor=black@.6:boxborderw=5[v540p];
+    [0:v]drawtext=x=(w-text_w)-5:y=5:fontsize=54:fontcolor=white:text='960x270':box=1:boxcolor=black@.6:boxborderw=5,scale=960x270[v270p]
+  " \
+  -map [v540p] \
+  -map [v270p] \
+  -map 1:a \
+  \
+  -c:v libx264 \
+    -preset:v veryfast \
+    -tune zerolatency \
+    -profile:v main \
+    -crf:v:0 23 -bufsize:v:0 2250k -maxrate:v:0 2500k \
+    -crf:v:1 23 -bufsize:v:1  540k -maxrate:v:1  600k \
+    -g:v 100000 -keyint_min:v 50000 -force_key_frames:v "expr:gte(t,n_forced*2)" \
+    -x264opts no-open-gop=1 \
+    -bf 2 -b_strategy 2 -refs 1 \
+    -rc-lookahead 24 \
+    -export_side_data prft \
+    -field_order progressive -colorspace bt709 -color_primaries bt709 -color_trc bt709 -color_range tv \
+    -pix_fmt yuv420p \
+  -c:a aac \
+    -b:a 64k \
+  \
+  -f hls \
+    -master_pl_name "master.m3u8" \
+    -hls_list_size 5 \
+    -hls_delete_threshold 1 \
+    -hls_start_number_source epoch \
+    -hls_fmp4_init_filename "init-%v.mp4" \
+    -hls_segment_filename "chunk-stream-%v-%010d.mp4" \
+    -hls_flags "+append_list+delete_segments+discont_start+program_date_time+independent_segments-temp_file" \
+    -var_stream_map "a:0,name:audio-64k,agroup:audio,default:yes v:0,name:video-720p,agroup:audio v:1,name:video-360p,agroup:audio" \
+    \
+    -hls_time 6 \
+    -hls_segment_type fmp4 \
+    -hls_segment_options "movflags=+cmaf+dash+delay_moov+skip_sidx+skip_trailer" \
+    "%v.m3u8"
+#Stop the docker container
+docker stop $nginx
+#And remove the test files we've generated
+rm -rf $temp /tmp/hls

--- a/fake-hls/nginx.conf
+++ b/fake-hls/nginx.conf
@@ -1,0 +1,84 @@
+# Defines the number of worker processes.    Setting it to the number of
+# available CPU cores should be a good start. The value `auto` will try to
+# autodetect that.
+worker_processes auto;
+
+# Configures logging to `/var/log/...`. Log level `error` is used by default.
+error_log    /var/log/nginx/error.log;
+
+# Defines a file that will store the process ID of the main process. This needs
+# to match the Systemd unit file.
+pid /run/nginx.pid;
+
+# Load dynamic modules. See /usr/share/nginx/README.dynamic.
+include /usr/share/nginx/modules/*.conf;
+
+events {
+    # Sets the maximum number of simultaneous connections that can be opened by
+    # a worker process.
+    worker_connections 1024;
+}
+
+
+http {
+    # Include mime types for different file extensions.
+    include /etc/nginx/mime.types;
+
+    # Defines the default MIME type of a response.
+    default_type application/octet-stream;
+
+    # Sendfile copies data between one file descriptor and other from within the
+    # kernel. This is more efficient than read() and write() since they require
+    # transferring data to and from the user space.
+    sendfile on;
+
+    # Todo: Write explanation
+    # https://t37.net/nginx-optimization-understanding-sendfile-tcp_nodelay-and-tcp_nopush.html
+    tcp_nopush on;
+    tcp_nodelay on;
+
+    # Disable access log.
+    #access_log /var/log/nginx/access.log;
+    access_log off;
+
+    # Enable on-the-fly gzip compression for larger plain text files and for
+    # proxies applications.
+    gzip            on;
+    gzip_comp_level 2;
+    gzip_min_length 1000;
+    gzip_proxied    expired no-cache no-store private auth;
+    gzip_types
+        application/javascript
+        application/json
+        application/x-javascript
+        application/xml
+        image/svg+xml
+        text/css
+        text/javascript
+        text/js
+        text/plain
+        text/xml;
+
+    # Do not send the nginx version number in error pages and Server header
+    server_tokens off;
+
+    server {
+        listen      80;
+        server_name _;
+
+        # Basic open CORS for everyone
+        add_header Access-Control-Allow-Origin $http_origin always;
+        add_header Access-Control-Allow-Methods 'GET, POST, OPTIONS' always;
+        add_header Access-Control-Allow-Credentials true always;
+        add_header Access-Control-Allow-Headers 'Origin,Content-Type,Accept,Authorization' always;
+
+        # Accept large ingests
+        client_max_body_size 0;
+
+        # Proxy configuration for Opencast
+        location / {
+            root /tmp;
+        }
+    }
+
+}

--- a/fake-hls/readme.md
+++ b/fake-hls/readme.md
@@ -1,0 +1,17 @@
+Fake HLS Streaming
+======================
+
+This script uses ffmpeg (use the Opencast release, or something very recent), and nginx's docker image to create a fake
+HLS streaming source.  This can be used to test that your live-streaming workflow and player work as expected.
+
+This script requires minor configuration of Opencast's `LiveScheduleServiceImpl.cfg`:
+ - `live.streamingUrl=http://localhost:8888/`
+ - `live.streamName=master.m3u8`
+
+Your workflow also needs to have `publishLive` set to true for the live streaming event to be properly listed in the
+search index.  Stream should be playable via VLC, ffplay, or other video players from http://localhost:8888/master.m3u8.
+You may need to wait a minute or two after starting the stream before it is properly playable.
+
+Usage:
+
+    bash fake-hls.sh


### PR DESCRIPTION
This PR uses docker, ffmpeg, and some shell glue to create a fake streaming source generating an ffmpeg test signal at the default live streaming resolutions
