### PR TITLE
Add script to see progress of current ffmpeg command

### DIFF
--- a/ffmpeg-progress/current-encode-progress.sh
+++ b/ffmpeg-progress/current-encode-progress.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# This script shows the rough encoding progress of the currently most CPU
+# intensive ffmpeg.
+
+# Find most CPU-intensive ffmpeg
+pid=$(ps -eo pid,pcpu,comm --sort=-pcpu | awk '$3=="ffmpeg"{print $1; exit}')
+if [ -z "$pid" ]; then
+    echo "no job"
+    exit 0
+fi
+
+# Get full command line and extract first input after -i
+cmd=$(ps -p "$pid" -o args=)
+input=$(printf "%s\n" "$cmd" | sed -n 's/.*-i[[:space:]]\+\([^[:space:]]\+\).*/\1/p')
+if [ -z "$input" ]; then
+    echo "could not parse input"
+    exit 1
+fi
+if [ ! -f "$input" ]; then
+    echo "input not a file: $input"
+    exit 1
+fi
+
+# Find fd pointing to that file
+fd=$(ls -l /proc/"$pid"/fd 2>/dev/null | awk -v f="$input" '$NF==f{print $9}')
+if [ -z "$fd" ]; then
+    echo "fd not found"
+    exit 1
+fi
+
+# read current offset
+pos=$(awk '/^pos:/ {print $2}' /proc/"$pid"/fdinfo/"$fd")
+size=$(stat -c %s "$input")
+pct=$(awk -v p="$pos" -v s="$size" 'BEGIN{printf "%.2f", (p/s)*100}')
+
+echo "$pct%   $input"


### PR DESCRIPTION
The script:

- Finds the most CPU-intensive ffmpeg process
- Parses its command line to find the input file
- Checks the fd of that file for that process
- Checks the byte offset of the process in the file
- Calculates the percentage

Like obviously, this might not be accurate for many reasons, but in my test it actually is very accurate. And it's an easy non-intrusive way to check progress. (I had way weirder ideas before :D). Most of the code was written by AI, as bash and in particular sed/awk stuff is really not my area of expertise, nor fun. But from looking over it, looks like even if there are random failures, nothing catastrophic would happen (I don't see any way these commands would ever *write* anything). And I tested it on OC explore. But as usual, maybe check the script yourself before running it on your production server ;-)